### PR TITLE
docs(plans): pnl attribution design + implementation (reviewed)

### DIFF
--- a/docs/plans/2026-05-11-pnl-attribution-design.md
+++ b/docs/plans/2026-05-11-pnl-attribution-design.md
@@ -43,9 +43,9 @@ Let one settled trade have:
 - `model_p_up_for_side` = `model_p_up` if `side == "up"` else `1 - model_p_up`.
 - `signal_ref_for_side` = `signal_reference_price` (already in side-aligned units — the executable entry on the chosen side).
 - `entry_for_side` = `entry_price` (likewise).
-- `fees` = `fee_shares(size, entry_price)` — shares-denominated fee from `config.py`.
+- `fees` = `fee_shares(size, entry_price)` — **recomputed from the realized `size` and `entry_price`** at attribution time, not read from `trades.fees`. `trades.fees` was logged at submit-time using *intended* size/price and is never updated; on live partial fills it diverges from the algebra-consistent fee. Recomputing here keeps every component scaled by the same realized trade.
 - `won = (side == outcome)`.
-- `realized_pnl = (size - fees) - entry_price * size` if `won`, else `-entry_price * size`.
+- `realized_pnl = (size - fees) - entry_price * size` if `won`, else `-entry_price * size` — *informational only*; the algebra below reads `realized_pnl` from `trades.pnl`, not from this formula.
 
 ### Decomposition (ex-ante fee variant — principal)
 
@@ -68,7 +68,7 @@ Sum identity (definitional): `edge + slip + expected_fee + luck ≡ realized_pnl
 
 ### Interpretation
 
-- **edge_value** — value of the model's bet at the price the gate said we were betting at. If the model is well-calibrated and aggregated over many trades, `sum(edge_value) ≈ sum(realized_pnl) - sum(slip) - sum(expected_fee)`. Negative average edge means we're firing trades where the model didn't actually disagree with the reference price after the gate's own thresholds applied — a config/threshold bug, not a model bug.
+- **edge_value** — raw probability-vs-price gap, `size * (model_p_for_side - signal_ref)`, **not** the same quantity the gate compares against `MIN_EDGE_THRESHOLD`. The gate uses `model_p_up - effective_ask(signal_ref)` where `effective_ask` inflates the price by the fee surcharge (`config.py:effective_ask`). The fee surcharge is therefore *not* fully absorbed into `expected_fee_value` — a ~1¢ wedge falls into `edge_value`. So `edge_value > 0` does **not** mean "the gate said yes net of fees"; for that interpretation you'd add `edge_value + expected_fee_value` and compare against zero. The two-term sum is what calibrates against `mean(luck) → 0`, not `edge_value` alone.
 - **slip_value** — signed VWAP slip from gate reference to actual fill. Captures IOC buffer drag, queue priority loss, and book moves between `t_signal` and `t_fill`. Should be ≤ 0 in expectation under the current "buffer-above-mid" execution policy; positive slip in aggregate means the book is moving in our favor between decision and fill (rare; usually a sign the decision was late).
 - **expected_fee_value** — fee budget in expectation. Strictly ≤ 0. Comparing `expected_fee` against `realized_fee` (= `-fees if won else 0`) over many trades surfaces whether we're paying fees more often than the model predicts (i.e., winning more than expected — a happy regime — or fees mis-spec'd).
 - **luck_value** — `realized − expected`. Mean across many trades should be ≈ 0 if the model is well-calibrated. Systematic non-zero mean ⇒ miscalibration; this is the same signal the per-bin reliability diagram surfaces, but in dollar units. The two should agree; if they disagree there is a coverage bug. (No new statistical claim — just a check.)
@@ -84,7 +84,7 @@ The report emits **both** columns (`expected_fee_value` is the principal; `reali
 
 ### Sum-identity unit tests (gating)
 
-Eight hand-built cases — `{up,down} × {win,loss} × {signal_ref < entry, signal_ref > entry}` — assert `|edge + slip + expected_fee + luck - realized_pnl| < 1e-9` for every case. A ninth case (fees=0, size=0 degenerate) checks the formula doesn't divide-by-anything.
+Eight hand-built cases — `{up,down} × {win,loss} × {signal_ref < entry, signal_ref > entry}` — assert `|edge + slip + expected_fee + luck - realized_pnl| < 1e-9` for every case.
 
 ## Required new data: `signal_reference_price` on `trades`
 
@@ -120,6 +120,8 @@ aggregate_attribution(rows: list[Attribution]) -> AggregateAttribution
 
 returning per-component sums, per-component means, count of rows with `signal_reference_source = "exact"` vs `"approximate"`, and the realized-vs-expected fee gap. The caller (TUI / report / analyze.py) decides the rolling window.
 
+**Model-version cohort split requires a join.** `model_p_up_v2` lives on `window_snapshots` (`ledger.py:125-126`), not on `trades`. Callers that want the v1/v2 split must fetch `model_p_up_v2` from the `decision` snapshot for each trade's `window_slug` and merge it into the row dict before passing to `aggregate_attribution`. A helper `attach_v2_cohort(rows, db_path)` in `polypocket/attribution.py` performs this join once; aggregate_attribution treats `model_p_up_v2` as optional (NULL → v1) so callers that don't care can skip the join.
+
 Three call sites:
 
 1. **TUI panel `AttributionPanel`** — left-aligned column showing rolling 20-trade and lifetime sums in USDC, refreshes on every settled-trade event. Lives next to the existing `StatusPanel`.
@@ -146,7 +148,7 @@ No change to `bot.py`, `observer.py`, `risk.py`, `fillmodel.py`, `backtester.py`
 - **Execution improvement.** The brainstorm's Tier-1 adaptive-buffer idea (#11) is a separate plan that *consumes* `slip_value` as its objective.
 - **Sizing improvement.** Fractional-Kelly (#21) consumes `edge_value` as its expected-return input but is a separate plan.
 - **Per-feature attribution (SHAP/LIME).** Out of scope — would require model internals and is overkill at n≈400 settled trades.
-- **Size-slip attribution.** Today every fill is FOK so `filled_size == intended_size` or the trade rejects. Once IOC partials are routine, a `size_slip_value` term will be needed; the schema reserves the conceptual slot but doesn't materialize it yet.
+- **Size-slip attribution.** Live executor uses IOC (`executor.py:341`) and accepts partial fills (`update_trade` overwrites `size` / `entry_price` to the realized VWAP). Paper rejects-or-fills-fully. A future `size_slip_value` term would attribute the cost of under-fill (e.g., intended_size − filled_size at the prevailing price). Out of scope here; the partial-fill data needed for it is recoverable from `order_events` `submit` payloads when the time comes. The present algebra papers over partials by recomputing `fees` from realized `size` / `entry_price` at attribution time so every component scales by the same realized trade.
 - **Real-time per-tick attribution.** Attribution materializes at settlement only. The brainstorm's "live edge histogram" (Idea #42) is the pre-fire view; attribution is the post-settle view.
 
 ## Acceptance
@@ -180,9 +182,11 @@ No change to `bot.py`, `observer.py`, `risk.py`, `fillmodel.py`, `backtester.py`
 
 3. **Calibration confounds luck.** If v1 is meaningfully miscalibrated (the #15 motivating finding), `sum(luck_value)` over the v1 corpus will be systematically non-zero, and a naive reader may interpret that as "model edge was overstated" rather than "model probability was miscalibrated". These are the same statement at the aggregate, but the per-trade decomposition will assign the gap to `luck`. Mitigation: the report's narrative paragraph explicitly cross-references the reliability section ("if the mean of `luck` exceeds its bootstrap CI under zero-error H0, model is miscalibrated, not unlucky"). Once v2 ships and calibrates the 0.80+ bin, `mean(luck)` on v2-attributed rows should drift toward zero — making attribution itself a v1-vs-v2 evaluation tool. The aggregator splits totals by inferred `MODEL_VERSION` (v1 vs v2) so this comparison is one query, not a join.
 
-4. **Cushion drift on historical backfill.** `SIGNAL_CUSHION_TICKS = 8` today; if it was different at a historical row's decision time, the backfill's recomputed `signal_reference_price` will not equal the value the gate actually used. The plan does not attempt to detect or correct this — the backfill uses the current constant, and the residual error lands in `slip_value`. Mitigation: documented as a known limitation. If cushion was retuned in the interim (Git-blameable), re-run the backfill against the affected date range as a one-off (manual). Single-author repo; cushion retunes are infrequent; cost of getting this wrong is small (a known constant bias on one cohort) versus the cost of building drift-detection infrastructure that may never be exercised.
+4. **Stranded-fill rows carry book drift inside slip.** `reconcile_recovered_trade` (`executor.py:120-122`) on a stranded-fill promote runs `update_trade(..., size=info.shares_held, entry_price=avg_price)` against a row whose `signal_reference_price` was persisted at the *original* decision time. The book moved between decision and the (eventually-observed) match; the resulting attribution attributes that drift to `slip_value` even when the original decision was clean. Mitigation: stranded-fill rows are rare (one observed per quarter) and the bias has a known sign (slip absorbs all post-decision book drift on those rows). Tag them `signal_reference_source = "stranded"` in a future revision if the cohort grows large enough to warrant separating; for now they're indistinguishable from `"live"`.
 
-5. **Aggregate-window cherry-picking.** Choosing the "right" rolling window post-hoc to make a tweak look good is the obvious anti-pattern. Mitigation: report fixes the windows (rolling 20, rolling 100, lifetime, last 7 days) and forbids new windows being added without a documented rationale; weekly report is the authoritative artifact, not ad-hoc TUI screenshots.
+5. **Cushion drift on historical backfill.** `SIGNAL_CUSHION_TICKS = 8` today; if it was different at a historical row's decision time, the backfill's recomputed `signal_reference_price` will not equal the value the gate actually used. The plan does not attempt to detect or correct this — the backfill uses the current constant, and the residual error lands in `slip_value`. Mitigation: documented as a known limitation. If cushion was retuned in the interim (Git-blameable), re-run the backfill against the affected date range as a one-off (manual). Single-author repo; cushion retunes are infrequent; cost of getting this wrong is small (a known constant bias on one cohort) versus the cost of building drift-detection infrastructure that may never be exercised.
+
+6. **Aggregate-window cherry-picking.** Choosing the "right" rolling window post-hoc to make a tweak look good is the obvious anti-pattern. Mitigation: report fixes the windows (rolling 20, rolling 100, lifetime, last 7 days) and forbids new windows being added without a documented rationale; weekly report is the authoritative artifact, not ad-hoc TUI screenshots.
 
 ## Out of scope (future)
 
@@ -195,14 +199,14 @@ No change to `bot.py`, `observer.py`, `risk.py`, `fillmodel.py`, `backtester.py`
 
 ## Artifact
 
-`scripts/_pnl_attribution.md` — committed report:
+`scripts/_pnl_attribution.md` — committed report (v1 scope):
 
-- Lifetime: `(N, realized_pnl, edge, slip, expected_fee, luck, realized_fee, fee_luck)` table.
-- Rolling 20-trade and rolling 100-trade aggregates.
-- Per-`model_p_up`-decile breakdown (mirror of reliability section).
-- Per-day trend (last 30d).
-- Top-5 slip-cost trades and top-5 luck-loss trades, with `window_slug` for replay.
-- Provenance counter: `N_exact / N_approximate / N_missing`.
+- Lifetime, rolling 100-trade, rolling 20-trade: `(N, realized_pnl, edge, slip, expected_fee, luck, fee_luck)` table per paper / live ledger.
+- Context line: same totals including approximate rows, for comparison.
+- Provenance counter: `N_exact / N_approximate / N_missing` and `n_unattributable_due_to_null_pnl`.
+- Model cohort: `v1-attributed` / `v2-attributed`.
+
+Decile breakdown, per-day trend, and top-5-trade tables are deferred — they slice attribution by a second axis (cohort, time, magnitude), which is the workstream listed under "Conditional cohort attribution" in §"Out of scope".
 
 `scripts/_backfill_signal_reference.md` — one-shot backfill log, including per-provenance counts and the aggregate exact-vs-approximate diff.
 

--- a/docs/plans/2026-05-11-pnl-attribution-design.md
+++ b/docs/plans/2026-05-11-pnl-attribution-design.md
@@ -1,0 +1,209 @@
+# PnL attribution — decompose realized PnL into edge / slip / fee / luck
+
+**Date:** 2026-05-11
+**Closes (if shipped):** a TBD-numbered issue tracking the diagnostic gap surfaced in `_bmad-output/brainstorming/brainstorming-session-2026-05-11-1901.md` (Idea #41); partially the diagnostic side of #13.
+**Depends on:** #15 dual-logging shipped (gives per-decision `model_p_up_v1_calibrated` and `model_p_up_v2`); #16 G1–G5 (decision rows carry `gate_config_json` and the bids that pin the gate-reference price).
+
+## Problem
+
+We can't tell *why* a trade lost. `analyze.py` today reports total PnL, win rate, and per-bin reliability. None of that distinguishes:
+
+- **Bad model** — `model_p_up=0.72` but the true bin rate is 0.55. The trade was a coin-flip dressed up as an edge.
+- **Bad fill** — model was right, but `entry_price=0.74` vs the `signal_reference=0.71` the gate compared against. The buffer (or queue position, or book move between decision and ack) ate the edge.
+- **Bad luck** — model right, fill clean, the coin landed against us. Keep firing.
+
+Every threshold-tune debate ("is v2 actually better?", "raise the IOC buffer?", "tighten `MAX_ENTRY_PRICE`?") collapses into the same `pnl < 0` signal without this split. The brainstorm of 2026-05-11 ranked PnL attribution as Tier-1 #1 precisely because every downstream Tier-1 idea — Kelly sizing (#21), adaptive buffer (#11), macro blackout (#9) — needs the split to be evaluable.
+
+The Brownian-vs-logistic dual-log (#15) is the same problem at the calibration layer; attribution is the same problem at the *outcome* layer. The two are complementary, not redundant: dual-log answers "is the model better?", attribution answers "given the model, where did the dollars go?"
+
+## Goal
+
+Ship a pure function
+
+```
+attribute_pnl(trade_row, decision_snapshot_row) -> PnlAttribution
+```
+
+returning a 4-component dataclass that *sums exactly to realized PnL* under one explicit algebra. Surface the components in three places:
+
+1. **Per-trade row** — augment `analyze.py`'s trades table with `edge_$`, `slip_$`, `fee_$`, `luck_$` columns.
+2. **Rolling aggregates** — new TUI panel showing trailing 20-trade and lifetime sums per component.
+3. **Weekly report** — `scripts/_pnl_attribution.md` auto-generated from the ledger, structured as "of $X realized over N trades, $A came from model edge, $B was given back to fills, $C was fee budget in expectation, $D was variance".
+
+Acceptance is **algebraic** (sum identity holds to float precision on every settled trade) and **operational** (decomposition matches intuition on three hand-replayed reference trades from the live and paper ledgers).
+
+## Math
+
+Let one settled trade have:
+
+- `side ∈ {up, down}` — the side bought.
+- `size` — shares held after fill (USDC at risk = `entry_price * size`).
+- `entry_price` — actual VWAP fill (post-fill update from `update_trade`).
+- `signal_reference_price` — the price the gate compared `model_p_up` against at decision time. For live: pair-merge clearing `1 - best_opp_bid + cushion_ticks`. For backtest/paper-perfect-fill: snapshot ask. **This is the new persisted field.**
+- `model_p_up_for_side` = `model_p_up` if `side == "up"` else `1 - model_p_up`.
+- `signal_ref_for_side` = `signal_reference_price` (already in side-aligned units — the executable entry on the chosen side).
+- `entry_for_side` = `entry_price` (likewise).
+- `fees` = `fee_shares(size, entry_price)` — shares-denominated fee from `config.py`.
+- `won = (side == outcome)`.
+- `realized_pnl = (size - fees) - entry_price * size` if `won`, else `-entry_price * size`.
+
+### Decomposition (ex-ante fee variant — principal)
+
+```
+edge_value         =  size * (model_p_up_for_side - signal_ref_for_side)
+slip_value         =  size * (signal_ref_for_side - entry_for_side)
+expected_fee_value = -fees * model_p_up_for_side
+luck_value         =  realized_pnl - (edge_value + slip_value + expected_fee_value)
+```
+
+`realized_pnl` is **read from `trades.pnl`** — the authoritative value written by `settle_paper_trade` or `settle_live_trade`. The decomposition does *not* recompute it from a formula, because on live trades the algebraic formula `(size - fees) - entry_price * size` diverges from `trades.pnl` by construction:
+
+- `trades.fees` is logged at trade-submit time from the *intended* `size`/`entry_price` and is **not** updated after the fill;
+- `trades.size` and `trades.entry_price` *are* overwritten with the actual fill VWAP / filled size in `update_trade`;
+- `settle_live_trade` computes `pnl = payout - info.cost_usdc` from CLOB-reported numbers, where `info.cost_usdc` does not necessarily equal `fill.filled_size * fill.avg_price` after Polymarket-side rounding and fee handling.
+
+Using `trades.pnl` directly preserves the sum identity by construction (`luck_value` is defined as the residual) and lets the same code run unchanged across paper and live ledgers. On live rows, `luck_value` absorbs both outcome-luck *and* the algebra-vs-CLOB accounting residual; that conflation is acknowledged in §"Top risks" and is split out as a future workstream rather than addressed here.
+
+Sum identity (definitional): `edge + slip + expected_fee + luck ≡ realized_pnl` for every row. The first three are deterministic at decision/fill time; `luck` carries all post-decision randomness (outcome) plus, on live rows, the small algebra-vs-CLOB accounting wedge.
+
+### Interpretation
+
+- **edge_value** — value of the model's bet at the price the gate said we were betting at. If the model is well-calibrated and aggregated over many trades, `sum(edge_value) ≈ sum(realized_pnl) - sum(slip) - sum(expected_fee)`. Negative average edge means we're firing trades where the model didn't actually disagree with the reference price after the gate's own thresholds applied — a config/threshold bug, not a model bug.
+- **slip_value** — signed VWAP slip from gate reference to actual fill. Captures IOC buffer drag, queue priority loss, and book moves between `t_signal` and `t_fill`. Should be ≤ 0 in expectation under the current "buffer-above-mid" execution policy; positive slip in aggregate means the book is moving in our favor between decision and fill (rare; usually a sign the decision was late).
+- **expected_fee_value** — fee budget in expectation. Strictly ≤ 0. Comparing `expected_fee` against `realized_fee` (= `-fees if won else 0`) over many trades surfaces whether we're paying fees more often than the model predicts (i.e., winning more than expected — a happy regime — or fees mis-spec'd).
+- **luck_value** — `realized − expected`. Mean across many trades should be ≈ 0 if the model is well-calibrated. Systematic non-zero mean ⇒ miscalibration; this is the same signal the per-bin reliability diagram surfaces, but in dollar units. The two should agree; if they disagree there is a coverage bug. (No new statistical claim — just a check.)
+
+### Why expected-fee, not realized-fee
+
+The conditional `-fees if won else 0` form is equally valid algebraically and matches what landed in the bank account. The trade-off:
+
+- **Expected-fee** isolates `luck` as *pure outcome surprise*. `sum(luck) ≈ 0` under a calibrated model is a clean falsifiable claim.
+- **Realized-fee** dumps the "we paid fees more/less than expected" wedge into `luck`, polluting the calibration check.
+
+The report emits **both** columns (`expected_fee_value` is the principal; `realized_fee_value = -fees * won` is shown alongside, and the gap `realized_fee_value - expected_fee_value` is labeled "fee-luck"). One row of the trades table; both summed in the aggregates.
+
+### Sum-identity unit tests (gating)
+
+Eight hand-built cases — `{up,down} × {win,loss} × {signal_ref < entry, signal_ref > entry}` — assert `|edge + slip + expected_fee + luck - realized_pnl| < 1e-9` for every case. A ninth case (fees=0, size=0 degenerate) checks the formula doesn't divide-by-anything.
+
+## Required new data: `signal_reference_price` on `trades`
+
+The decomposition cannot be derived without recording the price the gate compared against. Today the closest column is `market_p_up` on `trades`, which (per the v2 design doc's spot-check) persists raw `up_ask`, not the pair-merge `1 - best_down_bid + cushion`. Using `up_ask` to define edge here would systematically over-attribute to `edge` and under-attribute to `slip` (the same bias that drove +$0.075 mean live slippage per the slip-cushion plan).
+
+### Forward — persist on every new trade
+
+`polypocket/signal.py:106-109` already computes `up_entry`/`down_entry` (the pair-merge clearing prices). Plumb the side-aligned value through `Signal` and into `execute_paper_trade` / `execute_live_trade` as a new `signal_reference_price` arg, then through `log_trade` into a new nullable `trades.signal_reference_price REAL` column.
+
+This is a strict additive change: existing readers ignore the column; the `update_trade` path doesn't touch it; backfill (below) covers historical rows.
+
+### Backward — best-effort backfill
+
+For rows already in `paper_trades.db` / `live_trades.db`:
+
+- **Has `decision` snapshot with `up_bids_json` AND `down_bids_json` populated** (a minority of rows; see below): recompute `signal_reference_price` from `_effective_entry` exactly as `signal.py` does. Tag the row `signal_reference_source = "exact"`.
+- **Has `decision` snapshot but lacks the side-relevant bids JSON** (the majority): fall back to `up_ask`/`down_ask` from the snapshot. Tag `signal_reference_source = "approximate"`. On these rows, `slip_value` is biased toward 0 — it under-counts the pair-merge wedge (the gap between snapshot ask and the actual `1 - best_opp_bid + cushion` reference the gate used live).
+- **No `decision` snapshot at all** (very old paper rows): tag `signal_reference_source = "missing"`, leave `signal_reference_price = NULL`, exclude from aggregates with a clear log line.
+
+A second column `trades.signal_reference_source TEXT` records provenance for every row (forward rows get `"live"`). Backfill is one-shot via `scripts/backfill_signal_reference.py`; re-runs are idempotent (only touch rows where `signal_reference_source IS NULL`).
+
+**Empirical coverage as of 2026-05-11** (measured against the current `paper_trades.db`): 1368 of 4982 decision rows (27.5%) have non-null bids JSON. The bids-population coverage is **independent of G2** — G2 added `gate_config_json`, not bids. Bids JSON is written by `log_snapshot` only when the caller passes a `book_depth` dict containing `up_bids` / `down_bids`, which happened irregularly across the post-G2 paper soak. Implication: the backfill will tag **roughly 25–30% of historical rows `"exact"`, 65–70% `"approximate"`, and a small remainder `"missing"`**. The report and TUI must default to **excluding `"approximate"` from headline aggregates** (with the full-corpus number reported alongside as a context line) — otherwise the bias-toward-zero slip in approximate rows silently inflates `edge_sum` and deflates `slip_sum` for ~70% of the lifetime corpus.
+
+Forward rows (post-Task 4) are populated from the live computation in `signal.py`, not from re-reading bids JSON, so they are unaffected by bids-population gaps and land as `"live"` (semantically equivalent to `"exact"`).
+
+## Aggregation
+
+Three time-window aggregations, exposed as pure functions in `polypocket/attribution.py`:
+
+```
+aggregate_attribution(rows: list[Attribution]) -> AggregateAttribution
+```
+
+returning per-component sums, per-component means, count of rows with `signal_reference_source = "exact"` vs `"approximate"`, and the realized-vs-expected fee gap. The caller (TUI / report / analyze.py) decides the rolling window.
+
+Three call sites:
+
+1. **TUI panel `AttributionPanel`** — left-aligned column showing rolling 20-trade and lifetime sums in USDC, refreshes on every settled-trade event. Lives next to the existing `StatusPanel`.
+2. **`analyze.py` Section 7 "PnL attribution"** — markdown table for lifetime + last 20; per-bin breakdown by `model_p_up` decile (mirrors the existing reliability table layout so the two read side-by-side).
+3. **`scripts/pnl_attribution_report.py`** — emits `scripts/_pnl_attribution.md`. Manual or weekly-cron invocation. Identical content to the analyze.py section plus a per-day trend table.
+
+## Integration points
+
+- **`polypocket/ledger.py`** — `trades` gains two nullable columns (`signal_reference_price REAL`, `signal_reference_source TEXT`) via idempotent ALTER on `init_db`. `log_trade` signature gains `signal_reference_price: float | None = None, signal_reference_source: str = "live"`.
+- **`polypocket/signal.py`** — `Signal` gains `signal_reference_price: float` (the side-aligned value of `up_entry`/`down_entry` based on `side`).
+- **`polypocket/executor.py`** — `execute_paper_trade` and `execute_live_trade` accept the new field and pass it to `log_trade`. No behavioral change to gating, fills, or settlement.
+- **`polypocket/attribution.py`** *(new)* — pure-Python module: dataclass `PnlAttribution`, `attribute_pnl`, `aggregate_attribution`, `attribute_from_db`.
+- **`polypocket/analyze.py`** — new Section 7 below the existing reliability section.
+- **`polypocket/tui.py`** — new `AttributionPanel(Static)`; mounted alongside `StatusPanel`.
+- **`scripts/backfill_signal_reference.py`** *(new)* — one-shot backfill, idempotent.
+- **`scripts/pnl_attribution_report.py`** *(new)* — generates `scripts/_pnl_attribution.md`.
+- **`tests/`** — `test_attribution.py` (algebra + sum identity + backfill provenance handling), `test_ledger.py` (new column ALTER + log_trade signature), `test_signal.py` (signal_reference_price plumbing).
+
+No change to `bot.py`, `observer.py`, `risk.py`, `fillmodel.py`, `backtester.py`, the CLOB client, or the feeds. Attribution is a strictly post-hoc derived quantity over already-persisted state.
+
+## What this deliberately doesn't do
+
+- **Model improvement.** #15 / v2 logistic owns that. Attribution will *measure* whether v2 reduces the absolute mean of `luck_value` across calibration bins, but does not retrain.
+- **Execution improvement.** The brainstorm's Tier-1 adaptive-buffer idea (#11) is a separate plan that *consumes* `slip_value` as its objective.
+- **Sizing improvement.** Fractional-Kelly (#21) consumes `edge_value` as its expected-return input but is a separate plan.
+- **Per-feature attribution (SHAP/LIME).** Out of scope — would require model internals and is overkill at n≈400 settled trades.
+- **Size-slip attribution.** Today every fill is FOK so `filled_size == intended_size` or the trade rejects. Once IOC partials are routine, a `size_slip_value` term will be needed; the schema reserves the conceptual slot but doesn't materialize it yet.
+- **Real-time per-tick attribution.** Attribution materializes at settlement only. The brainstorm's "live edge histogram" (Idea #42) is the pre-fire view; attribution is the post-settle view.
+
+## Acceptance
+
+1. **Algebraic.** All 8 hand-built sum-identity unit tests pass to `|diff| < 1e-9 USDC`. A property test over 1000 random `(size, entry_price, signal_ref, model_p_up, side, won, realized_pnl)` tuples asserts the same. Since `realized_pnl` is an input (not a recomputation), the identity is true by construction and the test enforces that the implementation does not accidentally drop a term.
+2. **Backfill correctness.** Running `scripts/backfill_signal_reference.py` against the current `paper_trades.db`:
+   - Every settled trade with a `decision` snapshot containing both side-relevant non-null bids JSON values is tagged `"exact"`.
+   - Every settled trade with a `decision` snapshot lacking the side-relevant bids JSON is tagged `"approximate"`.
+   - Every settled trade with no `decision` snapshot is tagged `"missing"`.
+   - Re-running is a no-op (no row's columns change on second invocation).
+3. **Aggregate sanity (paper, exact rows only).** Over rows where `signal_reference_source = "exact"` AND `db_path = PAPER_DB_PATH`, `sum(trades.pnl) ≈ sum(edge + slip + expected_fee + luck)` to within `1e-6 USDC`. (Trivially true since `realized_pnl` comes from `trades.pnl`; the check guards against type-coercion bugs and dropped rows.) **No equivalent check is asserted on live or on approximate rows** — the algebra-vs-CLOB residual and the bids-fallback bias respectively make a tighter equality claim meaningless. The live aggregate is reported but not gated.
+4. **Cross-check against intuition.** Three reference trades, chosen manually from `paper_trades.db` (one clean win, one clean loss, one fill with ≥2-tick slip), produce attributions that match a hand-computation on the design doc's math, recorded in `scripts/_pnl_attribution_reference.md`. Tolerance: `math.isclose(actual, expected, abs_tol=1e-6)` per component.
+5. **Operational.** `analyze.py` runs to completion on `paper_trades.db`. If `live_trades.db` exists, it runs there too; if not, the report skips the live section with a clear note (no silent empty section). TUI starts and renders the panel on the paper ledger. Weekly report script emits a non-empty markdown file.
+
+## Definition of done
+
+- `trades.signal_reference_price` and `trades.signal_reference_source` columns shipped (idempotent ALTER).
+- `polypocket/attribution.py` shipped with full unit + property tests passing.
+- `signal.py` / `executor.py` / `ledger.py` plumbing committed; new live and paper trades persist `signal_reference_price` with `signal_reference_source = "live"`.
+- `scripts/backfill_signal_reference.py` shipped and run once against the current paper and live DBs; backfill log committed under `scripts/_backfill_signal_reference.md`.
+- `analyze.py` Section 7 shipped; sample report regenerated and committed (`scripts/_polypocket_report.md` or wherever the existing one lives).
+- `AttributionPanel` mounted in the TUI; smoke-tested by launching the TUI against `paper_trades.db`.
+- `scripts/pnl_attribution_report.py` shipped; first `scripts/_pnl_attribution.md` generated and committed.
+- 7 days of forward operation with `signal_reference_source = "live"` populating on every new settled trade; verified via a one-liner SQL count.
+
+## Top risks
+
+1. **Approximate rows dominate the historical corpus.** Empirically, ~70% of historical decision rows lack the side-relevant bids JSON and will be tagged `"approximate"`; the slip computation on those rows is biased toward zero, which inflates `edge_sum` and deflates `|slip_sum|`. Lifetime aggregates that silently include approximate rows therefore overstate model edge and understate execution drag. Mitigation: `aggregate_attribution` defaults to `include_approximate=False`. The report shows headline numbers from exact rows only, with an inclusive-of-approximate line reported alongside for context and clearly labeled. Forward-going rows (post-Task 4) are `"live"` and unaffected.
+
+2. **Live `realized_pnl` carries a CLOB-accounting residual inside `luck`.** On live rows, `trades.pnl` is computed from CLOB-reported `info.cost_usdc` and `info.shares_held`, which can differ from `size * entry_price` by Polymarket-side rounding and protocol fee handling; `trades.fees` is also the *intended* fee, not the realized one. The decomposition uses `trades.pnl` as authoritative `realized_pnl`, so the sum identity holds, but the algebra-vs-CLOB wedge falls into `luck_value`. Across many trades this is small and noisy and washes out; on a single trade it can be material. Mitigation: report the per-trade `luck_value` distribution alongside the aggregates; a future plan (out of scope here) can split `luck` into `outcome_luck` and `accounting_residual` by computing both formula PnL and CLOB PnL and differencing.
+
+3. **Calibration confounds luck.** If v1 is meaningfully miscalibrated (the #15 motivating finding), `sum(luck_value)` over the v1 corpus will be systematically non-zero, and a naive reader may interpret that as "model edge was overstated" rather than "model probability was miscalibrated". These are the same statement at the aggregate, but the per-trade decomposition will assign the gap to `luck`. Mitigation: the report's narrative paragraph explicitly cross-references the reliability section ("if the mean of `luck` exceeds its bootstrap CI under zero-error H0, model is miscalibrated, not unlucky"). Once v2 ships and calibrates the 0.80+ bin, `mean(luck)` on v2-attributed rows should drift toward zero — making attribution itself a v1-vs-v2 evaluation tool. The aggregator splits totals by inferred `MODEL_VERSION` (v1 vs v2) so this comparison is one query, not a join.
+
+4. **Cushion drift on historical backfill.** `SIGNAL_CUSHION_TICKS = 8` today; if it was different at a historical row's decision time, the backfill's recomputed `signal_reference_price` will not equal the value the gate actually used. The plan does not attempt to detect or correct this — the backfill uses the current constant, and the residual error lands in `slip_value`. Mitigation: documented as a known limitation. If cushion was retuned in the interim (Git-blameable), re-run the backfill against the affected date range as a one-off (manual). Single-author repo; cushion retunes are infrequent; cost of getting this wrong is small (a known constant bias on one cohort) versus the cost of building drift-detection infrastructure that may never be exercised.
+
+5. **Aggregate-window cherry-picking.** Choosing the "right" rolling window post-hoc to make a tweak look good is the obvious anti-pattern. Mitigation: report fixes the windows (rolling 20, rolling 100, lifetime, last 7 days) and forbids new windows being added without a documented rationale; weekly report is the authoritative artifact, not ad-hoc TUI screenshots.
+
+## Out of scope (future)
+
+- **Size-slip term** (requires routine IOC partials).
+- **Hedge-leg attribution** (requires multi-leg trades, e.g. Idea #89 settlement perp hedge).
+- **Cross-market portfolio attribution** (requires Idea #71 ETH/SOL expansion).
+- **LLM-generated narrative summaries** of weekly reports (Idea #111).
+- **Conditional cohort attribution** — "the losing trades concentrate in gate_config X / hour-of-day Y / `model_p_up` decile Z". The aggregator returns flat sums; slicing by cohort is the obvious next step but requires a second pass and a small cohort DSL. Out of scope here; the persisted per-trade attribution makes it straightforward to add.
+- **Split of `luck_value`** into `outcome_luck` (definitional surprise) and `accounting_residual` (algebra-vs-CLOB wedge on live rows). Requires recomputing the formula PnL in parallel and differencing; deferred until the live-rows accounting residual is measured and judged worth separating.
+
+## Artifact
+
+`scripts/_pnl_attribution.md` — committed report:
+
+- Lifetime: `(N, realized_pnl, edge, slip, expected_fee, luck, realized_fee, fee_luck)` table.
+- Rolling 20-trade and rolling 100-trade aggregates.
+- Per-`model_p_up`-decile breakdown (mirror of reliability section).
+- Per-day trend (last 30d).
+- Top-5 slip-cost trades and top-5 luck-loss trades, with `window_slug` for replay.
+- Provenance counter: `N_exact / N_approximate / N_missing`.
+
+`scripts/_backfill_signal_reference.md` — one-shot backfill log, including per-provenance counts and the aggregate exact-vs-approximate diff.
+
+`scripts/_pnl_attribution_reference.md` — three hand-replayed trades with the math written out, serving as an example and as a regression artifact.

--- a/docs/plans/2026-05-11-pnl-attribution-implementation.md
+++ b/docs/plans/2026-05-11-pnl-attribution-implementation.md
@@ -36,27 +36,40 @@ Expected: green. If it fails with `ModuleNotFoundError: scripts`, stop and add `
 
 ### Step 2: Capture baseline state for later verification
 
-Run:
+Write to a repo-local scratch file (already gitignored under `*.bak.db` siblings; this one we'll add to `.gitignore` in Task 5). Cross-platform: cwd-relative path works under both PowerShell and bash.
 
-```bash
-sqlite3 paper_trades.db "SELECT MAX(id) FROM trades" > /tmp/pre_attrib_max_trade_id.txt
-sqlite3 paper_trades.db "SELECT COUNT(*) FROM trades WHERE status='settled'" >> /tmp/pre_attrib_max_trade_id.txt
-sqlite3 paper_trades.db "SELECT COUNT(*), SUM(CASE WHEN up_bids_json IS NOT NULL AND down_bids_json IS NOT NULL THEN 1 ELSE 0 END) FROM window_snapshots WHERE snapshot_type='decision'" >> /tmp/pre_attrib_max_trade_id.txt
+PowerShell:
+```powershell
+$baseline = ".attrib_baseline.txt"
+sqlite3 paper_trades.db "SELECT MAX(id) FROM trades"                                           | Out-File -Encoding ascii $baseline
+sqlite3 paper_trades.db "SELECT COUNT(*) FROM trades WHERE status='settled'"                   | Out-File -Encoding ascii -Append $baseline
+sqlite3 paper_trades.db "SELECT COUNT(*), SUM(CASE WHEN up_bids_json IS NOT NULL AND up_bids_json NOT IN ('null','[]') AND down_bids_json IS NOT NULL AND down_bids_json NOT IN ('null','[]') THEN 1 ELSE 0 END) FROM window_snapshots WHERE snapshot_type='decision'" | Out-File -Encoding ascii -Append $baseline
 ```
 
-The captured `MAX(id)` becomes the boundary for Task 10 Step 4's 7-day forward-soak check. The bids-JSON count is the expected `"exact"` ceiling for the backfill in Task 5.
+bash / git-bash:
+```bash
+baseline=.attrib_baseline.txt
+sqlite3 paper_trades.db "SELECT MAX(id) FROM trades"                          >  $baseline
+sqlite3 paper_trades.db "SELECT COUNT(*) FROM trades WHERE status='settled'"  >> $baseline
+sqlite3 paper_trades.db "SELECT COUNT(*), SUM(CASE WHEN up_bids_json IS NOT NULL AND up_bids_json NOT IN ('null','[]') AND down_bids_json IS NOT NULL AND down_bids_json NOT IN ('null','[]') THEN 1 ELSE 0 END) FROM window_snapshots WHERE snapshot_type='decision'" >> $baseline
+```
 
-No commit; this is local diagnostic state.
+The captured `MAX(id)` becomes the boundary for Task 10 Step 4's 7-day forward-soak check. The bids-JSON count is the expected `"exact"` ceiling for the backfill — the predicate matches `_classify_and_compute` (NULL, `'null'`, and `'[]'` all tag approximate). On the current paper DB this drops the count by 2 (the two `'[]'` rows) vs the prior `IS NOT NULL`-only predicate.
+
+No commit; `.attrib_baseline.txt` is added to `.gitignore` in Task 5 Step 9.
 
 **Rollback:** N/A (read-only).
 
 ---
 
-## Task 1: Add `signal_reference_price` and `signal_reference_source` columns
+## Task 1: Add `signal_reference_price` + `signal_reference_source` columns; close the conftest gap on `SIGNAL_CUSHION_TICKS`
 
 **Files:**
 - Modify: `polypocket/ledger.py`
 - Modify: `tests/test_ledger.py`
+- Modify: `tests/conftest.py`
+
+> **Why conftest.py here:** Tasks 2 and 5 introduce tests that compute expected values from `SIGNAL_CUSHION_TICKS` (an env-backed constant per `config.py:21`). `tests/conftest.py:15-24` currently purges 7 env keys but does **not** purge `SIGNAL_CUSHION_TICKS` — a developer with `SIGNAL_CUSHION_TICKS=7` in their shell will silently get wrong test math. `project-context.md:81+:115` flags this category as "the single most common silent bug vector." Closed here so the conftest patch lands before the tests that depend on it. `IOC_BUFFER_TICKS` has the same exposure and is added in the same change.
 
 ### Step 1: Write failing test for the new columns
 
@@ -122,21 +135,40 @@ def log_trade(
     pnl: float | None,
     status: str,
     signal_reference_price: float | None = None,
-    signal_reference_source: str = "live",
+    signal_reference_source: str | None = None,
 ) -> int:
 ```
 
-Extend the INSERT column list and parameter tuple correspondingly. Defaults are chosen so all existing callers compile (`None` price / `"live"` source); callers are updated in Task 4.
+Extend the INSERT column list and parameter tuple correspondingly. Defaults are both `None` so existing callers (and ad-hoc test fixtures that don't care about attribution) leave the columns NULL — the Task 5 backfill then picks them up. The Task 4 executor callers explicitly pass `signal_reference_source="live"` to tag forward rows.
 
-### Step 4: Run tests
+### Step 4: Extend `tests/conftest.py`'s purge tuple
 
-Run: `pytest tests/test_ledger.py -v`. Expected: all green (new tests pass; existing tests unchanged).
+Edit `tests/conftest.py`. Add `"SIGNAL_CUSHION_TICKS"` and `"IOC_BUFFER_TICKS"` to the `_key` tuple. Final tuple should read:
 
-### Step 5: Commit
+```python
+for _key in (
+    "MIN_POSITION_USDC",
+    "MAX_POSITION_USDC",
+    "TRADING_MODE",
+    "FOK_SLIPPAGE_TICKS",
+    "DEPTH_CLAMP_BUFFER",
+    "MIN_FILL_RATIO",
+    "MAX_BOOK_AGE_S",
+    "SIGNAL_CUSHION_TICKS",
+    "IOC_BUFFER_TICKS",
+):
+    os.environ.pop(_key, None)
+```
+
+### Step 5: Run tests
+
+Run: `pytest tests/test_ledger.py -v`. Expected: all green (new tests pass; existing tests unchanged). Also run the whole signal suite to confirm the conftest change didn't break anything: `pytest tests/test_signal.py -v`.
+
+### Step 6: Commit
 
 ```bash
-git add polypocket/ledger.py tests/test_ledger.py
-git commit -m "feat(ledger): add signal_reference_price + source columns (PnL attribution)"
+git add polypocket/ledger.py tests/test_ledger.py tests/conftest.py
+git commit -m "feat(ledger): add signal_reference_price + source columns; close conftest gap (PnL attribution)"
 ```
 
 **Rollback:** `git revert HEAD`. New columns are nullable; existing readers unaffected.
@@ -155,14 +187,20 @@ Add to `tests/test_signal.py`:
 
 ```python
 def test_signal_populates_signal_reference_price_for_up_side():
-    """For a UP signal, signal_reference_price equals up_entry = (1 - best_down_bid) + cushion."""
+    """For a UP signal, signal_reference_price equals up_entry = (1 - best_down_bid) + cushion.
+
+    Inputs mirror tests/test_signal.py's existing UP-firing recipe (displacement
+    ≈1z over a 3min residual) so up_edge lands in the [MIN_EDGE_THRESHOLD,
+    MAX_EDGE_THRESHOLD_UP) firing band (config.py:10, :36). Picking larger
+    displacements pushes model_p_up past 0.99 and trips MAX_EDGE_THRESHOLD_UP.
+    """
     from polypocket.signal import SignalEngine
     from polypocket.config import SIGNAL_CUSHION_TICKS
 
     eng = SignalEngine()
     sig = eng.evaluate(
-        displacement=0.005, t_elapsed=120, t_remaining=180, sigma_5min=0.002,
-        up_ask=0.55, down_ask=0.50,
+        displacement=0.0009, t_elapsed=120, t_remaining=180, sigma_5min=0.0012,
+        up_ask=0.58, down_ask=0.50,
         up_bids=[{"price": 0.40}],
         down_bids=[{"price": 0.42}],
     )
@@ -173,20 +211,26 @@ def test_signal_populates_signal_reference_price_for_up_side():
 
 
 def test_signal_populates_signal_reference_price_for_down_side():
-    """For a DOWN signal, signal_reference_price = (1 - best_up_bid) + cushion."""
+    """For a DOWN signal, signal_reference_price = (1 - best_up_bid) + cushion.
+
+    DOWN side needs a higher best_up_bid (lowering down_entry below
+    effective_ask + MIN_EDGE_THRESHOLD_DOWN) AND CALIBRATION_SHRINKAGE_DOWN=0.50
+    is applied (config.py:50). The combination forces tighter inputs than UP.
+    """
     from polypocket.signal import SignalEngine
     from polypocket.config import SIGNAL_CUSHION_TICKS
 
     eng = SignalEngine()
     sig = eng.evaluate(
-        displacement=-0.005, t_elapsed=120, t_remaining=180, sigma_5min=0.002,
-        up_ask=0.50, down_ask=0.55,
-        up_bids=[{"price": 0.42}],
+        displacement=-0.0009, t_elapsed=120, t_remaining=180, sigma_5min=0.0012,
+        up_ask=0.50, down_ask=0.50,
+        up_bids=[{"price": 0.55}],   # high up_bid → low down_entry
         down_bids=[{"price": 0.40}],
     )
     assert sig is not None
     assert sig.side == "down"
-    expected = (1.0 - 0.42) + SIGNAL_CUSHION_TICKS * 0.01
+    # DOWN side's reference is (1 - best_up_bid) + cushion, NOT (1 - best_down_bid).
+    expected = (1.0 - 0.55) + SIGNAL_CUSHION_TICKS * 0.01
     assert sig.signal_reference_price == pytest.approx(expected, abs=1e-9)
 ```
 
@@ -267,6 +311,7 @@ from polypocket.attribution import (
     attribute_pnl,
     attribute_from_row,
     aggregate_attribution,
+    attach_v2_cohort,
 )
 
 
@@ -286,7 +331,11 @@ from polypocket.attribution import (
     ],
 )
 def test_sum_identity(side, won, signal_ref, entry_price):
-    """edge + slip + expected_fee + luck must equal realized_pnl to 1e-9."""
+    """edge + slip + expected_fee + luck must equal realized_pnl to 1e-9.
+
+    Note: attribute_pnl recomputes fees internally from realized size/entry_price.
+    The test supplies realized_pnl using the same formula so the identity is exact.
+    """
     from polypocket.config import fee_shares
 
     size = 50.0
@@ -298,7 +347,7 @@ def test_sum_identity(side, won, signal_ref, entry_price):
     attr = attribute_pnl(
         side=side, size=size, entry_price=entry_price,
         signal_reference_price=signal_ref, model_p_up=model_p_up,
-        fees=fees, outcome=outcome, realized_pnl=realized_pnl,
+        outcome=outcome, realized_pnl=realized_pnl,
     )
     total = attr.edge_value + attr.slip_value + attr.expected_fee_value + attr.luck_value
     assert abs(total - realized_pnl) < 1e-9, f"diff={total - realized_pnl:.2e}"
@@ -317,7 +366,7 @@ def test_signs_are_intuitive_up_win():
     attr = attribute_pnl(
         side="up", size=size, entry_price=entry_price,
         signal_reference_price=0.60, model_p_up=0.80,
-        fees=fees, outcome="up", realized_pnl=realized_pnl,
+        outcome="up", realized_pnl=realized_pnl,
     )
     assert attr.edge_value > 0
     assert attr.slip_value < 0
@@ -349,7 +398,7 @@ def test_sum_identity_property():
         attr = attribute_pnl(
             side=side, size=size, entry_price=entry_price,
             signal_reference_price=signal_ref, model_p_up=model_p_up,
-            fees=fees, outcome=outcome, realized_pnl=realized_pnl,
+            outcome=outcome, realized_pnl=realized_pnl,
         )
         total = attr.edge_value + attr.slip_value + attr.expected_fee_value + attr.luck_value
         assert abs(total - realized_pnl) < 1e-9
@@ -362,17 +411,21 @@ def test_attribute_from_row_handles_missing_signal_reference():
     (caller must filter; aggregates skip these)."""
     row = {
         "side": "up", "size": 50.0, "entry_price": 0.60,
-        "fees": 0.025, "model_p_up": 0.70, "outcome": "up", "pnl": 19.975,
+        "model_p_up": 0.70, "outcome": "up", "pnl": 19.975,
         "signal_reference_price": None, "signal_reference_source": "missing",
     }
     assert attribute_from_row(row) is None
 
 
 def test_attribute_from_row_returns_pnl_attribution_when_complete():
-    """Complete row produces a PnlAttribution using trades.pnl as realized_pnl."""
+    """Complete row produces a PnlAttribution using trades.pnl as realized_pnl.
+
+    fees are recomputed from realized size/entry_price — the row's `fees` field
+    is not read (it's the intended fee, see design §"Math").
+    """
     row = {
         "side": "up", "size": 100.0, "entry_price": 0.62,
-        "fees": 0.0472, "model_p_up": 0.80, "outcome": "up", "pnl": 37.953,
+        "model_p_up": 0.80, "outcome": "up", "pnl": 37.953,
         "signal_reference_price": 0.60, "signal_reference_source": "exact",
     }
     attr = attribute_from_row(row)
@@ -385,7 +438,7 @@ def test_attribute_from_row_requires_pnl():
     """Rows without trades.pnl (unsettled or settled-with-null) are unattributable."""
     row = {
         "side": "up", "size": 100.0, "entry_price": 0.62,
-        "fees": 0.0472, "model_p_up": 0.80, "outcome": "up", "pnl": None,
+        "model_p_up": 0.80, "outcome": "up", "pnl": None,
         "signal_reference_price": 0.60, "signal_reference_source": "exact",
     }
     assert attribute_from_row(row) is None
@@ -397,25 +450,34 @@ def _make_row(slug, source="exact", pnl=1.0, model_p_up=0.70,
               model_p_up_v2=None, entry_price=0.60, signal_ref=0.55):
     return {
         "window_slug": slug, "side": "up", "size": 10.0, "entry_price": entry_price,
-        "fees": 0.005, "model_p_up": model_p_up, "outcome": "up", "pnl": pnl,
+        "model_p_up": model_p_up, "outcome": "up", "pnl": pnl,
         "signal_reference_price": signal_ref, "signal_reference_source": source,
         "model_p_up_v2": model_p_up_v2,
     }
 
 
-def test_aggregate_counts_provenance():
+def test_aggregate_counts_provenance_from_attributable_rows_only():
+    """n_exact/n_approximate/n_missing count only rows that produced an
+    attribution. Rows dropped for null pnl land in n_unattributable instead."""
     rows = [
         _make_row("w1", "exact"),
         _make_row("w2", "exact"),
         _make_row("w3", "approximate"),
         _make_row("w4", "missing"),
         _make_row("w5", None),  # NULL source treated as missing
+        _make_row("w6", "exact", pnl=None),  # null pnl: unattributable
     ]
-    agg = aggregate_attribution(rows)
-    assert agg.n_total == 5
-    assert agg.n_exact == 2
-    assert agg.n_approximate == 1
-    assert agg.n_missing == 2
+    rows[3]["signal_reference_price"] = None  # missing rows have null reference
+    rows[4]["signal_reference_price"] = None
+    agg = aggregate_attribution(rows, include_approximate=True)
+    assert agg.n_total == 6
+    assert agg.n_exact == 2          # w1, w2 (w6 dropped to n_unattributable)
+    assert agg.n_approximate == 1    # w3
+    assert agg.n_missing == 2        # w4, w5
+    assert agg.n_unattributable == 1 # w6
+    # Sanity: counted buckets account for every row.
+    assert (agg.n_exact + agg.n_approximate + agg.n_missing
+            + agg.n_unattributable) == agg.n_total
 
 
 def test_aggregate_excludes_approximate_by_default():
@@ -448,8 +510,14 @@ def test_aggregate_excludes_missing_unconditionally():
     assert agg.realized_pnl == pytest.approx(1.0, abs=1e-9)
 
 
-def test_aggregate_infers_model_version():
-    """A row is v2-cohort iff model_p_up == model_p_up_v2 (the v2 value was the one that fired)."""
+def test_aggregate_infers_model_version_from_joined_v2_column():
+    """A row is v2-cohort iff model_p_up == model_p_up_v2 (the v2 value fired).
+
+    model_p_up_v2 lives on window_snapshots, not trades — callers must use
+    attach_v2_cohort() before passing rows to aggregate_attribution. This test
+    pre-joins the column inline; integration coverage of attach_v2_cohort lives
+    in test_attach_v2_cohort_joins_decision_snapshot below.
+    """
     rows = [
         _make_row("w1", "exact", pnl=1.0, model_p_up=0.70, model_p_up_v2=0.62),  # v1
         _make_row("w2", "exact", pnl=2.0, model_p_up=0.62, model_p_up_v2=0.62),  # v2
@@ -457,6 +525,53 @@ def test_aggregate_infers_model_version():
     agg = aggregate_attribution(rows)
     assert agg.n_v1_attributed == 1
     assert agg.n_v2_attributed == 1
+
+
+def test_aggregate_treats_missing_model_p_up_v2_as_v1():
+    """A row whose model_p_up_v2 key is absent (pre-#15 dual-log, or no join
+    performed) is classified v1, not crashed."""
+    rows = [
+        _make_row("w1", "exact", pnl=1.0, model_p_up=0.70, model_p_up_v2=None),
+    ]
+    rows[0].pop("model_p_up_v2")  # key entirely absent
+    agg = aggregate_attribution(rows)
+    assert agg.n_v1_attributed == 1
+    assert agg.n_v2_attributed == 0
+
+
+def test_attach_v2_cohort_joins_decision_snapshot(tmp_path):
+    """attach_v2_cohort fetches model_p_up_v2 from window_snapshots and merges
+    it into each row dict. Rows without a decision snapshot get None."""
+    from polypocket.ledger import init_db, log_trade, log_snapshot
+    from polypocket.attribution import attach_v2_cohort
+
+    db = str(tmp_path / "j.db")
+    init_db(db)
+    log_trade(db_path=db, window_slug="w1", side="up", entry_price=0.6, size=10.0,
+              fees=0.024, model_p_up=0.7, market_p_up=0.58, edge=0.12,
+              outcome="up", pnl=3.976, status="settled",
+              signal_reference_price=0.58, signal_reference_source="live")
+    log_snapshot(db, "w1", "decision", {
+        "btc_price": 65000, "window_open_price": 64900,
+        "displacement": 0.0015, "sigma_5min": 0.002, "model_p_up": 0.70,
+        "t_remaining": 200, "up_ask": 0.58, "down_ask": 0.42,
+        "market_p_up": 0.58, "edge": 0.12, "preview_side": "up",
+        "quote_status": "ok",
+        "model_p_up_v1_calibrated": 0.70, "model_p_up_v2": 0.62,
+    })
+    # Second trade lacks a decision snapshot.
+    log_trade(db_path=db, window_slug="w2", side="up", entry_price=0.6, size=10.0,
+              fees=0.024, model_p_up=0.7, market_p_up=0.58, edge=0.12,
+              outcome="up", pnl=3.976, status="settled",
+              signal_reference_price=0.58, signal_reference_source="live")
+
+    rows = [
+        {"window_slug": "w1", "model_p_up": 0.70},
+        {"window_slug": "w2", "model_p_up": 0.70},
+    ]
+    joined = attach_v2_cohort(rows, db)
+    assert joined[0]["model_p_up_v2"] == pytest.approx(0.62, abs=1e-9)
+    assert joined[1]["model_p_up_v2"] is None
 ```
 
 Run: `pytest tests/test_attribution.py -v`. Expected: all FAIL on `ModuleNotFoundError`.
@@ -476,9 +591,23 @@ live ledgers). The decomposition does NOT recompute realized_pnl from a
 formula, because on live trades the algebraic formula diverges from
 trades.pnl (see design doc §"Decomposition").
 
+Fees are recomputed internally from realized size/entry_price via
+`config.fee_shares` — `trades.fees` is the intended fee (logged at submit-time
+from intended values, never refreshed). On live partial fills, intended ≠
+realized; recomputing here keeps every component scaled by the same trade.
+
+Model-version (v1 vs v2) cohort assignment requires `model_p_up_v2` from
+window_snapshots — use `attach_v2_cohort(rows, db_path)` before passing to
+aggregate_attribution if you want the split. Without the join, all rows are
+classified v1.
+
 See docs/plans/2026-05-11-pnl-attribution-design.md for the full algebra.
 """
+import sqlite3
+from contextlib import closing
 from dataclasses import dataclass
+
+from polypocket.config import fee_shares
 
 
 @dataclass(frozen=True)
@@ -488,7 +617,12 @@ class PnlAttribution:
     slip_value: float
     expected_fee_value: float
     luck_value: float
-    # Auxiliary (reported alongside, not in the principal sum):
+    # Auxiliary (reported alongside, not in the principal sum). `realized_fee_value`
+    # is `-fees if won else 0` using the *recomputed* fee from realized
+    # size/entry_price — accurate on paper; on live it's the "fee that would
+    # have been paid at the realized fill price if Polymarket's fee schedule
+    # matched our formula exactly." Algebra-vs-CLOB residual on live is
+    # absorbed into luck_value (design risk #2).
     realized_fee_value: float
     fee_luck_value: float  # realized_fee_value - expected_fee_value
     # Provenance + cohort
@@ -507,7 +641,6 @@ def attribute_pnl(
     entry_price: float,
     signal_reference_price: float,
     model_p_up: float,
-    fees: float,
     outcome: str,
     realized_pnl: float,
     signal_reference_source: str = "live",
@@ -517,20 +650,23 @@ def attribute_pnl(
 
     Args:
       side: 'up' or 'down' — the side the trade bought.
-      size: shares held after fill.
-      entry_price: actual VWAP fill (post-fill `update_trade` value on live).
+      size: shares held after fill (realized, from trades.size post-update).
+      entry_price: actual VWAP fill (realized, from trades.entry_price post-update).
       signal_reference_price: the price the gate compared model_p_up against.
         Side-aligned (i.e., the executable entry on the chosen side).
       model_p_up: P(BTC up) at decision; this function flips for DOWN side.
-      fees: trades.fees — the *intended* fee (logged from intended size/price).
-        On live, this is an estimate; on paper, it equals the realized fee on win.
       outcome: 'up' or 'down' — the resolved outcome.
       realized_pnl: trades.pnl — authoritative realized PnL from the settle path.
       signal_reference_source: provenance tag for the reference price.
       model_version_attributed: 'v1' or 'v2' — which model drove this trade.
+
+    Note: fees are intentionally NOT a parameter. They are recomputed from
+    realized size/entry_price via config.fee_shares so the algebra is
+    internally consistent across paper, live full fills, and live partial fills.
     """
     won = side == outcome
     model_p_for_side = _side_aligned_model_p(model_p_up, side)
+    fees = fee_shares(size, entry_price)
     edge_value = size * (model_p_for_side - signal_reference_price)
     slip_value = size * (signal_reference_price - entry_price)
     expected_fee_value = -fees * model_p_for_side
@@ -556,7 +692,8 @@ def _infer_model_version(row: dict) -> str:
     """Infer which model drove the trade by comparing model_p_up with model_p_up_v2.
 
     Per signal.py:99-102, trades.model_p_up == model_p_up_v2 iff MODEL_VERSION=v2
-    was active. If the v2 column is NULL (pre-#15 dual-logging) treat as v1.
+    was active. If the v2 column is NULL or absent (pre-#15 dual-logging, or
+    the caller skipped attach_v2_cohort) treat as v1.
     """
     v2 = row.get("model_p_up_v2")
     if v2 is None:
@@ -569,8 +706,10 @@ def attribute_from_row(row: dict) -> PnlAttribution | None:
 
     Skips rows missing pnl, signal_reference_price, outcome, or any required field.
     Use this in aggregation loops; callers should filter Nones and count them.
+
+    `fees` is NOT in the required set — it's recomputed inside attribute_pnl.
     """
-    required = ("side", "size", "entry_price", "fees", "model_p_up",
+    required = ("side", "size", "entry_price", "model_p_up",
                 "outcome", "signal_reference_price", "pnl")
     for key in required:
         if row.get(key) is None:
@@ -578,19 +717,56 @@ def attribute_from_row(row: dict) -> PnlAttribution | None:
     return attribute_pnl(
         side=row["side"], size=row["size"], entry_price=row["entry_price"],
         signal_reference_price=row["signal_reference_price"],
-        model_p_up=row["model_p_up"], fees=row["fees"],
+        model_p_up=row["model_p_up"],
         outcome=row["outcome"], realized_pnl=row["pnl"],
         signal_reference_source=row.get("signal_reference_source") or "unknown",
         model_version_attributed=_infer_model_version(row),
     )
 
 
+def attach_v2_cohort(rows: list[dict], db_path: str) -> list[dict]:
+    """Join model_p_up_v2 from window_snapshots into each row by window_slug.
+
+    Pure helper for callers (analyze.py, render_attribution_text, report) that
+    want the v1/v2 cohort split. `model_p_up_v2` lives on window_snapshots
+    (#15 dual-logging), not trades — without this join, _infer_model_version
+    classifies every row as v1.
+
+    Rows are returned as new dicts (shallow-copied + augmented); the input
+    list is not mutated. Rows whose window_slug has no decision snapshot get
+    model_p_up_v2 = None.
+    """
+    slugs = [r["window_slug"] for r in rows if r.get("window_slug")]
+    if not slugs:
+        return [dict(r) for r in rows]
+    placeholders = ",".join("?" * len(slugs))
+    by_slug: dict[str, float | None] = {}
+    with closing(sqlite3.connect(db_path)) as conn:
+        for slug, v2 in conn.execute(
+            f"SELECT window_slug, model_p_up_v2 FROM window_snapshots "
+            f"WHERE snapshot_type='decision' AND window_slug IN ({placeholders})",
+            slugs,
+        ).fetchall():
+            by_slug[slug] = v2
+    out = []
+    for r in rows:
+        new = dict(r)
+        new["model_p_up_v2"] = by_slug.get(r.get("window_slug"))
+        out.append(new)
+    return out
+
+
 @dataclass(frozen=True)
 class AggregateAttribution:
+    # n_total = n_exact + n_approximate + n_missing + n_unattributable.
+    # The first three are *attributable* rows (have non-null pnl / signal_ref);
+    # n_unattributable counts rows dropped despite a valid provenance tag
+    # (typically null pnl from settle_live_trade lookup failures).
     n_total: int
     n_exact: int
     n_approximate: int
     n_missing: int
+    n_unattributable: int
     n_v1_attributed: int
     n_v2_attributed: int
     realized_pnl: float
@@ -616,26 +792,50 @@ def aggregate_attribution(
 
     Missing-source rows are excluded unconditionally (no signal_reference_price
     to attribute against).
+
+    Provenance counts come from the SAME pass that builds the sums — a row
+    tagged 'exact' but dropped because pnl IS NULL lands in n_unattributable,
+    not n_exact, so the four count buckets sum to n_total.
     """
     n_total = len(rows)
-    n_exact = sum(1 for r in rows if r.get("signal_reference_source") == "exact"
-                  or r.get("signal_reference_source") == "live")
-    n_approximate = sum(1 for r in rows if r.get("signal_reference_source") == "approximate")
-    n_missing = sum(
-        1 for r in rows
-        if r.get("signal_reference_source") in (None, "missing")
-        or r.get("signal_reference_price") is None
-    )
-
+    n_exact = n_approximate = n_missing = n_unattributable = 0
     n_v1 = n_v2 = 0
     realized_pnl = edge_sum = slip_sum = expected_fee_sum = luck_sum = 0.0
     realized_fee_sum = fee_luck_sum = 0.0
+
     for r in rows:
-        if not include_approximate and r.get("signal_reference_source") == "approximate":
+        src = r.get("signal_reference_source")
+        # Classify provenance before attribution attempt; final bucket may
+        # downgrade to n_unattributable if attribute_from_row returns None
+        # for a reason other than missing reference (e.g., null pnl).
+        if src in (None, "missing") or r.get("signal_reference_price") is None:
+            provenance = "missing"
+        elif src == "approximate":
+            provenance = "approximate"
+        else:  # 'exact' or 'live'
+            provenance = "exact"
+
+        if provenance == "approximate" and not include_approximate:
+            n_approximate += 1
             continue
+
         a = attribute_from_row(r)
         if a is None:
+            if provenance == "missing":
+                n_missing += 1
+            else:
+                n_unattributable += 1
             continue
+
+        # Successful attribution — count by provenance, accumulate sums.
+        if provenance == "exact":
+            n_exact += 1
+        elif provenance == "approximate":
+            n_approximate += 1
+        else:  # provenance == "missing" but attribute_from_row returned non-None
+            # (shouldn't happen — missing implies null reference — but defensive)
+            n_missing += 1
+
         realized_pnl += a.realized_pnl
         edge_sum += a.edge_value
         slip_sum += a.slip_value
@@ -649,7 +849,8 @@ def aggregate_attribution(
             n_v1 += 1
 
     return AggregateAttribution(
-        n_total=n_total, n_exact=n_exact, n_approximate=n_approximate, n_missing=n_missing,
+        n_total=n_total, n_exact=n_exact, n_approximate=n_approximate,
+        n_missing=n_missing, n_unattributable=n_unattributable,
         n_v1_attributed=n_v1, n_v2_attributed=n_v2,
         realized_pnl=realized_pnl, edge_sum=edge_sum, slip_sum=slip_sum,
         expected_fee_sum=expected_fee_sum, luck_sum=luck_sum,
@@ -659,7 +860,7 @@ def aggregate_attribution(
 
 ### Step 3: Run tests
 
-Run: `pytest tests/test_attribution.py -v`. Expected: all green (8 parametric, 1 intuition, 1 property, 3 row-adapter, 5 aggregator = 18 tests).
+Run: `pytest tests/test_attribution.py -v`. Expected: all green (8 parametric sum-identity, 1 intuition, 1 property, 3 row-adapter, 7 aggregator+join = 20 tests).
 
 ### Step 4: Commit
 
@@ -1023,14 +1224,23 @@ Write `scripts/_backfill_signal_reference.md`:
 - Task 10 Step 4's forward-soak boundary is MAX(trades.id) = N_PRE.
 ```
 
-Fill `N_PRE` / `M_PRE` / `K_PRE` / `TOTAL_DECISION_PRE` from the file written in Task 0 Step 2.
+Fill `N_PRE` / `M_PRE` / `K_PRE` / `TOTAL_DECISION_PRE` from `.attrib_baseline.txt` written in Task 0 Step 2.
 
-### Step 9: Commit
+### Step 9: Gitignore the local baseline file
+
+Append to `.gitignore`:
+
+```
+# PnL attribution local baseline (captured at Task 0; never committed).
+.attrib_baseline.txt
+```
+
+### Step 10: Commit
 
 ```bash
 git add polypocket/executor.py tests/test_executor.py \
         scripts/backfill_signal_reference.py tests/test_backfill_signal_reference.py \
-        scripts/_backfill_signal_reference.md
+        scripts/_backfill_signal_reference.md .gitignore
 git commit -m "feat(attribution): persist signal_reference_price live + backfill history"
 ```
 
@@ -1052,11 +1262,22 @@ In `polypocket/analyze.py`, after the existing reliability section, add:
     h2("7. PnL Attribution")
     # ================================================================
 
-    from polypocket.attribution import aggregate_attribution
+    from polypocket.attribution import aggregate_attribution, attach_v2_cohort
 
-    agg_lifetime = aggregate_attribution(settled)
-    agg_lifetime_all = aggregate_attribution(settled, include_approximate=True)
-    agg_last20 = aggregate_attribution(settled[-20:]) if settled else None
+    # Re-fetch settled rows in id order — analyze.py's top-level `trades` is
+    # ORDER BY timestamp, which can diverge from id order on backfilled rows.
+    # All three attribution surfaces (analyze, TUI, report) standardize on id.
+    settled_by_id = sorted(
+        [t for t in trades if t["status"] == "settled"],
+        key=lambda t: t["id"],
+    )
+    # Join model_p_up_v2 from window_snapshots so the v1/v2 cohort split works
+    # (model_p_up_v2 is not on the trades table).
+    settled_joined = attach_v2_cohort(settled_by_id, db_path)
+
+    agg_lifetime = aggregate_attribution(settled_joined)
+    agg_lifetime_all = aggregate_attribution(settled_joined, include_approximate=True)
+    agg_last20 = aggregate_attribution(settled_joined[-20:]) if settled_joined else None
 
     def _fmt_agg(label, a) -> list:
         if a is None or a.n_total == 0:
@@ -1086,20 +1307,26 @@ In `polypocket/analyze.py`, after the existing reliability section, add:
       f"slip=${agg_lifetime_all.slip_sum:+.2f}")
     p(f"**Provenance:** exact/live={agg_lifetime.n_exact}, "
       f"approximate={agg_lifetime.n_approximate}, "
-      f"missing={agg_lifetime.n_missing}")
+      f"missing={agg_lifetime.n_missing}, "
+      f"unattributable={agg_lifetime.n_unattributable}")
     p(f"**Model cohort:** v1-attributed={agg_lifetime.n_v1_attributed}, "
       f"v2-attributed={agg_lifetime.n_v2_attributed}")
 ```
 
 ### Step 2: Smoke test on the actual DB
 
-Run the report:
+Run the report (cross-platform: write to cwd; remove after inspection):
 
 ```bash
-python -c "from polypocket.analyze import generate_report; print(generate_report('paper_trades.db'))" > /tmp/report.md
+python -c "from polypocket.analyze import generate_report; print(generate_report('paper_trades.db'))" > _section7_smoke.md
 ```
 
-Expected: report includes a "7. PnL Attribution" section with non-empty numbers and both headline and context lines. Sanity: `Realized` in the context (all rows) equals the sum of `pnl` from settled trades where `signal_reference_source` is not `"missing"` and `pnl` is not NULL.
+PowerShell equivalent:
+```powershell
+python -c "from polypocket.analyze import generate_report; print(generate_report('paper_trades.db'))" | Out-File -Encoding utf8 _section7_smoke.md
+```
+
+Expected: report includes a "7. PnL Attribution" section with non-empty numbers and both headline and context lines. Sanity: `Realized` in the context (all rows) equals the sum of `pnl` from settled trades where `signal_reference_source` is not `"missing"` and `pnl` is not NULL. Delete `_section7_smoke.md` after inspecting; it's not tracked.
 
 ### Step 3: Commit
 
@@ -1131,7 +1358,7 @@ def render_attribution_text(db_path: str) -> str:
     """
     import sqlite3
     from contextlib import closing
-    from polypocket.attribution import aggregate_attribution
+    from polypocket.attribution import aggregate_attribution, attach_v2_cohort
 
     with closing(sqlite3.connect(db_path)) as conn:
         conn.row_factory = sqlite3.Row
@@ -1139,6 +1366,8 @@ def render_attribution_text(db_path: str) -> str:
             "SELECT * FROM trades WHERE status='settled' ORDER BY id"
         ).fetchall()]
 
+    # Join model_p_up_v2 so the v1/v2 cohort line reflects reality.
+    all_settled = attach_v2_cohort(all_settled, db_path)
     last20 = all_settled[-20:]
     agg_life = aggregate_attribution(all_settled)
     agg_20 = aggregate_attribution(last20)
@@ -1158,7 +1387,8 @@ def render_attribution_text(db_path: str) -> str:
     lines.append(f"  {fmt(agg_20)}")
     lines.append("")
     lines.append(f"Provenance: exact/live={agg_life.n_exact} "
-                 f"approx={agg_life.n_approximate} missing={agg_life.n_missing}")
+                 f"approx={agg_life.n_approximate} missing={agg_life.n_missing} "
+                 f"unattributable={agg_life.n_unattributable}")
     lines.append(f"Cohort: v1={agg_life.n_v1_attributed} v2={agg_life.n_v2_attributed}")
     return "\n".join(lines)
 
@@ -1249,18 +1479,24 @@ from contextlib import closing
 from datetime import datetime, timezone
 from pathlib import Path
 
-from polypocket.attribution import aggregate_attribution
+from polypocket.attribution import aggregate_attribution, attach_v2_cohort
 from polypocket.config import LIVE_DB_PATH, PAPER_DB_PATH
 
 
 def _load_settled(db_path: str) -> list[dict]:
+    """Return settled trades joined with model_p_up_v2 from window_snapshots.
+
+    Empty list if the DB does not exist. ORDER BY id (not timestamp) so the
+    rows[-20:] / rows[-100:] slices match analyze.py and the TUI.
+    """
     if not os.path.exists(db_path):
         return []
     with closing(sqlite3.connect(db_path)) as conn:
         conn.row_factory = sqlite3.Row
-        return [dict(r) for r in conn.execute(
+        rows = [dict(r) for r in conn.execute(
             "SELECT * FROM trades WHERE status='settled' ORDER BY id"
         ).fetchall()]
+    return attach_v2_cohort(rows, db_path)
 
 
 def _section(name: str, rows: list[dict]) -> list[str]:
@@ -1289,7 +1525,8 @@ def _section(name: str, rows: list[dict]) -> list[str]:
     )
     out.append(
         f"**Provenance:** exact/live={agg_life.n_exact}, "
-        f"approximate={agg_life.n_approximate}, missing={agg_life.n_missing}\n"
+        f"approximate={agg_life.n_approximate}, missing={agg_life.n_missing}, "
+        f"unattributable={agg_life.n_unattributable}\n"
     )
     out.append(
         f"**Model cohort:** v1-attributed={agg_life.n_v1_attributed}, "

--- a/docs/plans/2026-05-11-pnl-attribution-implementation.md
+++ b/docs/plans/2026-05-11-pnl-attribution-implementation.md
@@ -1,0 +1,1518 @@
+# PnL attribution Implementation Plan
+
+> **For Claude:** Execute in-chat, one task at a time, linearly. No parallel subagents. Each task has file paths, concrete commands, and a verification + rollback line.
+>
+> **Revised 2026-05-11** after adversarial review surfaced 20 findings against the original draft. Key changes: `realized_pnl` is now sourced from `trades.pnl` (not recomputed from a formula that diverges on live rows); aggregator defaults to excluding `"approximate"` rows; test assertions reference `SIGNAL_CUSHION_TICKS` instead of hardcoded ranges; Task 0 added for pytest-import precondition; cross-platform backup commands; Task 4 and Task 5 are bundled to avoid an intermediate state where new code reads NULL columns.
+
+**Goal:** Ship the 4-component PnL decomposition (`edge`, `slip`, `expected_fee`, `luck`) from `docs/plans/2026-05-11-pnl-attribution-design.md`. Sum identity holds to float precision on every settled trade; surfaces in `analyze.py`, the TUI, and a weekly markdown report.
+
+**Architecture:** Pure module `polypocket/attribution.py` with no side effects, fed by two persisted fields on `trades` (`signal_reference_price`, `signal_reference_source`). `realized_pnl` is read from `trades.pnl` (authoritative for both paper and live). New trades populate via `signal.py → executor.py → log_trade`. Historical rows populate via a one-shot idempotent backfill script. Aggregations are pure functions consumed by three reporters.
+
+**Tech stack:** Python ≥3.11 stdlib only for the core (`sqlite3`, `dataclasses`, `math`). `textual` for the TUI panel (already a dep). `pytest` + `pytest-asyncio` for tests. No new third-party deps.
+
+**Design doc:** `docs/plans/2026-05-11-pnl-attribution-design.md`.
+
+**Related:** #15 (dual-logging — already shipped, supplies `model_p_up_v1_calibrated` / `model_p_up_v2`); #16 / G1–G5 (data capture — supplies the `up_bids_json` / `down_bids_json` that exact backfill needs, where populated); brainstorm 2026-05-11 Idea #41.
+
+---
+
+## Pre-decision (user, before Task 1)
+
+**Q1 — expected-fee vs realized-fee as the principal column.** Design defaults to expected-fee for the principal `fee_value` (clean `mean(luck) → 0` under calibration). Both are reported. If realized-fee should be principal, say so before Task 3; otherwise default holds.
+
+---
+
+## Task 0: Pre-flight — verify pytest can import from `scripts/`
+
+**Purpose:** Several tasks below import `from scripts.<name> import ...` in test files. `scripts/` is not a Python package (no `__init__.py`). The existing tests (`tests/test_export_training_corpus.py`, `tests/test_cohort_watchdog.py`) do the same and work, which means pytest's `rootdir` is already on `sys.path` via `conftest.py` or `pyproject.toml`. Confirm this is still the case before authoring new tests that depend on it.
+
+### Step 1: Confirm the pattern works today
+
+```bash
+pytest tests/test_export_training_corpus.py -k "test_join_returns_labeled_decisions" -v
+```
+
+Expected: green. If it fails with `ModuleNotFoundError: scripts`, stop and add `scripts/__init__.py` (or extend `pyproject.toml`'s `[tool.pytest.ini_options]` with `pythonpath = ["."]`) before proceeding.
+
+### Step 2: Capture baseline state for later verification
+
+Run:
+
+```bash
+sqlite3 paper_trades.db "SELECT MAX(id) FROM trades" > /tmp/pre_attrib_max_trade_id.txt
+sqlite3 paper_trades.db "SELECT COUNT(*) FROM trades WHERE status='settled'" >> /tmp/pre_attrib_max_trade_id.txt
+sqlite3 paper_trades.db "SELECT COUNT(*), SUM(CASE WHEN up_bids_json IS NOT NULL AND down_bids_json IS NOT NULL THEN 1 ELSE 0 END) FROM window_snapshots WHERE snapshot_type='decision'" >> /tmp/pre_attrib_max_trade_id.txt
+```
+
+The captured `MAX(id)` becomes the boundary for Task 10 Step 4's 7-day forward-soak check. The bids-JSON count is the expected `"exact"` ceiling for the backfill in Task 5.
+
+No commit; this is local diagnostic state.
+
+**Rollback:** N/A (read-only).
+
+---
+
+## Task 1: Add `signal_reference_price` and `signal_reference_source` columns
+
+**Files:**
+- Modify: `polypocket/ledger.py`
+- Modify: `tests/test_ledger.py`
+
+### Step 1: Write failing test for the new columns
+
+Add to `tests/test_ledger.py`:
+
+```python
+def test_init_db_adds_signal_reference_columns(tmp_path):
+    """trades table gains signal_reference_price + signal_reference_source as nullable columns."""
+    import sqlite3
+    from polypocket.ledger import init_db
+
+    db = str(tmp_path / "t.db")
+    init_db(db)
+    with sqlite3.connect(db) as c:
+        cols = {row[1]: row[2] for row in c.execute("PRAGMA table_info(trades)").fetchall()}
+    assert cols.get("signal_reference_price") == "REAL"
+    assert cols.get("signal_reference_source") == "TEXT"
+
+
+def test_init_db_signal_reference_columns_are_idempotent(tmp_path):
+    """Calling init_db twice does not error and does not duplicate columns."""
+    import sqlite3
+    from polypocket.ledger import init_db
+
+    db = str(tmp_path / "t.db")
+    init_db(db)
+    init_db(db)
+    with sqlite3.connect(db) as c:
+        col_count = sum(1 for row in c.execute("PRAGMA table_info(trades)").fetchall()
+                        if row[1] == "signal_reference_price")
+    assert col_count == 1
+```
+
+Run: `pytest tests/test_ledger.py -k signal_reference -v`. Expected: both FAIL on missing columns.
+
+### Step 2: Add idempotent ALTER statements in `init_db`
+
+In `polypocket/ledger.py`, inside the existing `existing_cols = {row[1] for row in conn.execute("PRAGMA table_info(trades)").fetchall()}` block (around line 72), add:
+
+```python
+            if "signal_reference_price" not in existing_cols:
+                conn.execute("ALTER TABLE trades ADD COLUMN signal_reference_price REAL")
+            if "signal_reference_source" not in existing_cols:
+                conn.execute("ALTER TABLE trades ADD COLUMN signal_reference_source TEXT")
+```
+
+### Step 3: Extend `log_trade` signature
+
+Modify `log_trade` in `polypocket/ledger.py` to accept the new fields:
+
+```python
+def log_trade(
+    db_path: str,
+    window_slug: str,
+    side: str,
+    entry_price: float,
+    size: float,
+    fees: float,
+    model_p_up: float,
+    market_p_up: float,
+    edge: float,
+    outcome: str | None,
+    pnl: float | None,
+    status: str,
+    signal_reference_price: float | None = None,
+    signal_reference_source: str = "live",
+) -> int:
+```
+
+Extend the INSERT column list and parameter tuple correspondingly. Defaults are chosen so all existing callers compile (`None` price / `"live"` source); callers are updated in Task 4.
+
+### Step 4: Run tests
+
+Run: `pytest tests/test_ledger.py -v`. Expected: all green (new tests pass; existing tests unchanged).
+
+### Step 5: Commit
+
+```bash
+git add polypocket/ledger.py tests/test_ledger.py
+git commit -m "feat(ledger): add signal_reference_price + source columns (PnL attribution)"
+```
+
+**Rollback:** `git revert HEAD`. New columns are nullable; existing readers unaffected.
+
+---
+
+## Task 2: Thread `signal_reference_price` through `Signal`
+
+**Files:**
+- Modify: `polypocket/signal.py`
+- Modify: `tests/test_signal.py`
+
+### Step 1: Write failing tests
+
+Add to `tests/test_signal.py`:
+
+```python
+def test_signal_populates_signal_reference_price_for_up_side():
+    """For a UP signal, signal_reference_price equals up_entry = (1 - best_down_bid) + cushion."""
+    from polypocket.signal import SignalEngine
+    from polypocket.config import SIGNAL_CUSHION_TICKS
+
+    eng = SignalEngine()
+    sig = eng.evaluate(
+        displacement=0.005, t_elapsed=120, t_remaining=180, sigma_5min=0.002,
+        up_ask=0.55, down_ask=0.50,
+        up_bids=[{"price": 0.40}],
+        down_bids=[{"price": 0.42}],
+    )
+    assert sig is not None
+    assert sig.side == "up"
+    expected = (1.0 - 0.42) + SIGNAL_CUSHION_TICKS * 0.01
+    assert sig.signal_reference_price == pytest.approx(expected, abs=1e-9)
+
+
+def test_signal_populates_signal_reference_price_for_down_side():
+    """For a DOWN signal, signal_reference_price = (1 - best_up_bid) + cushion."""
+    from polypocket.signal import SignalEngine
+    from polypocket.config import SIGNAL_CUSHION_TICKS
+
+    eng = SignalEngine()
+    sig = eng.evaluate(
+        displacement=-0.005, t_elapsed=120, t_remaining=180, sigma_5min=0.002,
+        up_ask=0.50, down_ask=0.55,
+        up_bids=[{"price": 0.42}],
+        down_bids=[{"price": 0.40}],
+    )
+    assert sig is not None
+    assert sig.side == "down"
+    expected = (1.0 - 0.42) + SIGNAL_CUSHION_TICKS * 0.01
+    assert sig.signal_reference_price == pytest.approx(expected, abs=1e-9)
+```
+
+Add `import pytest` to the test file if not present.
+
+Run: `pytest tests/test_signal.py -k signal_reference -v`. Expected: AttributeError / failures on missing field.
+
+### Step 2: Add field to `Signal` dataclass
+
+In `polypocket/signal.py`, extend `Signal`:
+
+```python
+@dataclass
+class Signal:
+    side: str
+    model_p_up: float
+    market_price: float
+    edge: float
+    up_edge: float
+    down_edge: float
+    model_p_up_raw: float | None = None
+    model_p_up_v1_calibrated: float | None = None
+    model_p_up_v2: float | None = None
+    signal_reference_price: float | None = None
+```
+
+### Step 3: Populate at signal-construction sites
+
+In `SignalEngine.evaluate`, both the UP and DOWN `return Signal(...)` calls (currently lines ~128 and ~140), add:
+
+- UP branch: `signal_reference_price=up_entry,`
+- DOWN branch: `signal_reference_price=down_entry,`
+
+(`up_entry` and `down_entry` are already computed locally at lines 106–107.)
+
+### Step 4: Run tests
+
+Run: `pytest tests/test_signal.py -v`. Expected: all green.
+
+### Step 5: Commit
+
+```bash
+git add polypocket/signal.py tests/test_signal.py
+git commit -m "feat(signal): expose signal_reference_price on Signal (PnL attribution)"
+```
+
+**Rollback:** `git revert HEAD`.
+
+---
+
+## Task 3: Implement `polypocket/attribution.py` with TDD
+
+**Files:**
+- Create: `polypocket/attribution.py`
+- Create: `tests/test_attribution.py`
+
+### Step 1: Write the algebra and aggregator tests first (will fail with ModuleNotFoundError)
+
+Create `tests/test_attribution.py`:
+
+```python
+"""Algebraic and identity tests for PnL attribution.
+
+Sum identity (definitional): edge + slip + expected_fee + luck == realized_pnl
+for every settled trade, to float precision. realized_pnl is an *input* to the
+decomposition (sourced from trades.pnl), so the identity is true by
+construction — these tests guard against the implementation accidentally
+dropping a term or mis-aligning side semantics.
+"""
+import math
+import random
+
+import pytest
+
+from polypocket.attribution import (
+    PnlAttribution,
+    AggregateAttribution,
+    attribute_pnl,
+    attribute_from_row,
+    aggregate_attribution,
+)
+
+
+# --- Eight hand-built canonical cases for the sum identity ----------
+
+@pytest.mark.parametrize(
+    "side, won, signal_ref, entry_price",
+    [
+        ("up",   True,  0.55, 0.58),  # UP win, slip against us
+        ("up",   True,  0.58, 0.55),  # UP win, slip in our favor
+        ("up",   False, 0.55, 0.58),  # UP loss, slip against
+        ("up",   False, 0.58, 0.55),  # UP loss, slip in favor
+        ("down", True,  0.55, 0.58),
+        ("down", True,  0.58, 0.55),
+        ("down", False, 0.55, 0.58),
+        ("down", False, 0.58, 0.55),
+    ],
+)
+def test_sum_identity(side, won, signal_ref, entry_price):
+    """edge + slip + expected_fee + luck must equal realized_pnl to 1e-9."""
+    from polypocket.config import fee_shares
+
+    size = 50.0
+    model_p_up = 0.68
+    fees = fee_shares(size, entry_price)
+    outcome = side if won else ("down" if side == "up" else "up")
+    realized_pnl = ((size - fees) - entry_price * size) if won else (-entry_price * size)
+
+    attr = attribute_pnl(
+        side=side, size=size, entry_price=entry_price,
+        signal_reference_price=signal_ref, model_p_up=model_p_up,
+        fees=fees, outcome=outcome, realized_pnl=realized_pnl,
+    )
+    total = attr.edge_value + attr.slip_value + attr.expected_fee_value + attr.luck_value
+    assert abs(total - realized_pnl) < 1e-9, f"diff={total - realized_pnl:.2e}"
+    assert attr.realized_pnl == pytest.approx(realized_pnl, abs=1e-9)
+
+
+def test_signs_are_intuitive_up_win():
+    """UP win, model=0.80, gate-ref=0.60, fill=0.62: most PnL → edge; small negative slip;
+    small negative expected_fee; positive luck (won at p=0.80, residual = (size-fees)*(1-0.80))."""
+    from polypocket.config import fee_shares
+
+    size = 100.0
+    entry_price = 0.62
+    fees = fee_shares(size, entry_price)
+    realized_pnl = (size - fees) - entry_price * size
+    attr = attribute_pnl(
+        side="up", size=size, entry_price=entry_price,
+        signal_reference_price=0.60, model_p_up=0.80,
+        fees=fees, outcome="up", realized_pnl=realized_pnl,
+    )
+    assert attr.edge_value > 0
+    assert attr.slip_value < 0
+    assert attr.expected_fee_value < 0
+    assert attr.luck_value >= 0
+    # luck should equal (size - fees) * (1 - model_p_up_for_side)
+    assert attr.luck_value == pytest.approx((size - fees) * 0.20, abs=1e-9)
+
+
+# --- Property test: random tuples preserve sum identity -------------
+
+def test_sum_identity_property():
+    """Identity is definitional but mis-aligning side semantics or dropping a
+    term would break it. 1000 random tuples shake out coding errors."""
+    from polypocket.config import fee_shares
+
+    rng = random.Random(0)
+    for _ in range(1000):
+        side = rng.choice(["up", "down"])
+        outcome = rng.choice(["up", "down"])
+        size = rng.uniform(1.0, 200.0)
+        entry_price = rng.uniform(0.05, 0.95)
+        signal_ref = rng.uniform(0.05, 0.95)
+        model_p_up = rng.uniform(0.01, 0.99)
+        fees = fee_shares(size, entry_price)
+        won = side == outcome
+        realized_pnl = ((size - fees) - entry_price * size) if won else (-entry_price * size)
+
+        attr = attribute_pnl(
+            side=side, size=size, entry_price=entry_price,
+            signal_reference_price=signal_ref, model_p_up=model_p_up,
+            fees=fees, outcome=outcome, realized_pnl=realized_pnl,
+        )
+        total = attr.edge_value + attr.slip_value + attr.expected_fee_value + attr.luck_value
+        assert abs(total - realized_pnl) < 1e-9
+
+
+# --- DB-row adapter -------------------------------------------------
+
+def test_attribute_from_row_handles_missing_signal_reference():
+    """When signal_reference_price is NULL, attribute_from_row returns None
+    (caller must filter; aggregates skip these)."""
+    row = {
+        "side": "up", "size": 50.0, "entry_price": 0.60,
+        "fees": 0.025, "model_p_up": 0.70, "outcome": "up", "pnl": 19.975,
+        "signal_reference_price": None, "signal_reference_source": "missing",
+    }
+    assert attribute_from_row(row) is None
+
+
+def test_attribute_from_row_returns_pnl_attribution_when_complete():
+    """Complete row produces a PnlAttribution using trades.pnl as realized_pnl."""
+    row = {
+        "side": "up", "size": 100.0, "entry_price": 0.62,
+        "fees": 0.0472, "model_p_up": 0.80, "outcome": "up", "pnl": 37.953,
+        "signal_reference_price": 0.60, "signal_reference_source": "exact",
+    }
+    attr = attribute_from_row(row)
+    assert attr is not None
+    assert isinstance(attr, PnlAttribution)
+    assert attr.realized_pnl == pytest.approx(37.953, abs=1e-9)
+
+
+def test_attribute_from_row_requires_pnl():
+    """Rows without trades.pnl (unsettled or settled-with-null) are unattributable."""
+    row = {
+        "side": "up", "size": 100.0, "entry_price": 0.62,
+        "fees": 0.0472, "model_p_up": 0.80, "outcome": "up", "pnl": None,
+        "signal_reference_price": 0.60, "signal_reference_source": "exact",
+    }
+    assert attribute_from_row(row) is None
+
+
+# --- Aggregator -----------------------------------------------------
+
+def _make_row(slug, source="exact", pnl=1.0, model_p_up=0.70,
+              model_p_up_v2=None, entry_price=0.60, signal_ref=0.55):
+    return {
+        "window_slug": slug, "side": "up", "size": 10.0, "entry_price": entry_price,
+        "fees": 0.005, "model_p_up": model_p_up, "outcome": "up", "pnl": pnl,
+        "signal_reference_price": signal_ref, "signal_reference_source": source,
+        "model_p_up_v2": model_p_up_v2,
+    }
+
+
+def test_aggregate_counts_provenance():
+    rows = [
+        _make_row("w1", "exact"),
+        _make_row("w2", "exact"),
+        _make_row("w3", "approximate"),
+        _make_row("w4", "missing"),
+        _make_row("w5", None),  # NULL source treated as missing
+    ]
+    agg = aggregate_attribution(rows)
+    assert agg.n_total == 5
+    assert agg.n_exact == 2
+    assert agg.n_approximate == 1
+    assert agg.n_missing == 2
+
+
+def test_aggregate_excludes_approximate_by_default():
+    """Default behavior: approximate rows contribute to counts but not to sums."""
+    rows = [
+        _make_row("w1", "exact", pnl=1.0),
+        _make_row("w2", "approximate", pnl=999.0),  # would dominate if included
+    ]
+    agg = aggregate_attribution(rows)
+    assert agg.realized_pnl == pytest.approx(1.0, abs=1e-9)
+
+
+def test_aggregate_includes_approximate_when_asked():
+    rows = [
+        _make_row("w1", "exact", pnl=1.0),
+        _make_row("w2", "approximate", pnl=999.0),
+    ]
+    agg = aggregate_attribution(rows, include_approximate=True)
+    assert agg.realized_pnl == pytest.approx(1000.0, abs=1e-9)
+
+
+def test_aggregate_excludes_missing_unconditionally():
+    """Missing-source rows have NULL signal_reference_price and cannot be attributed."""
+    rows = [
+        _make_row("w1", "exact", pnl=1.0),
+        _make_row("w2", "missing", pnl=999.0),
+    ]
+    rows[1]["signal_reference_price"] = None
+    agg = aggregate_attribution(rows, include_approximate=True)
+    assert agg.realized_pnl == pytest.approx(1.0, abs=1e-9)
+
+
+def test_aggregate_infers_model_version():
+    """A row is v2-cohort iff model_p_up == model_p_up_v2 (the v2 value was the one that fired)."""
+    rows = [
+        _make_row("w1", "exact", pnl=1.0, model_p_up=0.70, model_p_up_v2=0.62),  # v1
+        _make_row("w2", "exact", pnl=2.0, model_p_up=0.62, model_p_up_v2=0.62),  # v2
+    ]
+    agg = aggregate_attribution(rows)
+    assert agg.n_v1_attributed == 1
+    assert agg.n_v2_attributed == 1
+```
+
+Run: `pytest tests/test_attribution.py -v`. Expected: all FAIL on `ModuleNotFoundError`.
+
+### Step 2: Implement `polypocket/attribution.py`
+
+Create `polypocket/attribution.py`:
+
+```python
+"""Pure PnL attribution: decompose realized PnL into edge / slip / expected_fee / luck.
+
+Sum identity: edge_value + slip_value + expected_fee_value + luck_value == realized_pnl
+to float precision, by construction (luck_value is defined as the residual).
+
+realized_pnl is sourced from `trades.pnl` (authoritative for both paper and
+live ledgers). The decomposition does NOT recompute realized_pnl from a
+formula, because on live trades the algebraic formula diverges from
+trades.pnl (see design doc §"Decomposition").
+
+See docs/plans/2026-05-11-pnl-attribution-design.md for the full algebra.
+"""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PnlAttribution:
+    realized_pnl: float
+    edge_value: float
+    slip_value: float
+    expected_fee_value: float
+    luck_value: float
+    # Auxiliary (reported alongside, not in the principal sum):
+    realized_fee_value: float
+    fee_luck_value: float  # realized_fee_value - expected_fee_value
+    # Provenance + cohort
+    signal_reference_source: str = "live"
+    model_version_attributed: str = "v1"  # "v1" or "v2"; see attribute_from_row
+
+
+def _side_aligned_model_p(model_p_up: float, side: str) -> float:
+    return model_p_up if side == "up" else 1.0 - model_p_up
+
+
+def attribute_pnl(
+    *,
+    side: str,
+    size: float,
+    entry_price: float,
+    signal_reference_price: float,
+    model_p_up: float,
+    fees: float,
+    outcome: str,
+    realized_pnl: float,
+    signal_reference_source: str = "live",
+    model_version_attributed: str = "v1",
+) -> PnlAttribution:
+    """Decompose realized PnL into the four principal components.
+
+    Args:
+      side: 'up' or 'down' — the side the trade bought.
+      size: shares held after fill.
+      entry_price: actual VWAP fill (post-fill `update_trade` value on live).
+      signal_reference_price: the price the gate compared model_p_up against.
+        Side-aligned (i.e., the executable entry on the chosen side).
+      model_p_up: P(BTC up) at decision; this function flips for DOWN side.
+      fees: trades.fees — the *intended* fee (logged from intended size/price).
+        On live, this is an estimate; on paper, it equals the realized fee on win.
+      outcome: 'up' or 'down' — the resolved outcome.
+      realized_pnl: trades.pnl — authoritative realized PnL from the settle path.
+      signal_reference_source: provenance tag for the reference price.
+      model_version_attributed: 'v1' or 'v2' — which model drove this trade.
+    """
+    won = side == outcome
+    model_p_for_side = _side_aligned_model_p(model_p_up, side)
+    edge_value = size * (model_p_for_side - signal_reference_price)
+    slip_value = size * (signal_reference_price - entry_price)
+    expected_fee_value = -fees * model_p_for_side
+    luck_value = realized_pnl - (edge_value + slip_value + expected_fee_value)
+
+    realized_fee_value = -fees if won else 0.0
+    fee_luck_value = realized_fee_value - expected_fee_value
+
+    return PnlAttribution(
+        realized_pnl=realized_pnl,
+        edge_value=edge_value,
+        slip_value=slip_value,
+        expected_fee_value=expected_fee_value,
+        luck_value=luck_value,
+        realized_fee_value=realized_fee_value,
+        fee_luck_value=fee_luck_value,
+        signal_reference_source=signal_reference_source,
+        model_version_attributed=model_version_attributed,
+    )
+
+
+def _infer_model_version(row: dict) -> str:
+    """Infer which model drove the trade by comparing model_p_up with model_p_up_v2.
+
+    Per signal.py:99-102, trades.model_p_up == model_p_up_v2 iff MODEL_VERSION=v2
+    was active. If the v2 column is NULL (pre-#15 dual-logging) treat as v1.
+    """
+    v2 = row.get("model_p_up_v2")
+    if v2 is None:
+        return "v1"
+    return "v2" if abs(row["model_p_up"] - v2) < 1e-9 else "v1"
+
+
+def attribute_from_row(row: dict) -> PnlAttribution | None:
+    """Adapter: takes a trades-table row dict; returns None if not attributable.
+
+    Skips rows missing pnl, signal_reference_price, outcome, or any required field.
+    Use this in aggregation loops; callers should filter Nones and count them.
+    """
+    required = ("side", "size", "entry_price", "fees", "model_p_up",
+                "outcome", "signal_reference_price", "pnl")
+    for key in required:
+        if row.get(key) is None:
+            return None
+    return attribute_pnl(
+        side=row["side"], size=row["size"], entry_price=row["entry_price"],
+        signal_reference_price=row["signal_reference_price"],
+        model_p_up=row["model_p_up"], fees=row["fees"],
+        outcome=row["outcome"], realized_pnl=row["pnl"],
+        signal_reference_source=row.get("signal_reference_source") or "unknown",
+        model_version_attributed=_infer_model_version(row),
+    )
+
+
+@dataclass(frozen=True)
+class AggregateAttribution:
+    n_total: int
+    n_exact: int
+    n_approximate: int
+    n_missing: int
+    n_v1_attributed: int
+    n_v2_attributed: int
+    realized_pnl: float
+    edge_sum: float
+    slip_sum: float
+    expected_fee_sum: float
+    luck_sum: float
+    realized_fee_sum: float
+    fee_luck_sum: float
+
+
+def aggregate_attribution(
+    rows: list[dict], *, include_approximate: bool = False
+) -> AggregateAttribution:
+    """Aggregate per-component sums over a list of trades rows.
+
+    DEFAULT: excludes signal_reference_source='approximate' rows from the sums
+    (still counted in n_approximate). Approximate rows have biased-toward-zero
+    slip and would inflate edge_sum; the design's headline aggregates report
+    exact rows only.
+
+    Pass include_approximate=True for a context line alongside the headline.
+
+    Missing-source rows are excluded unconditionally (no signal_reference_price
+    to attribute against).
+    """
+    n_total = len(rows)
+    n_exact = sum(1 for r in rows if r.get("signal_reference_source") == "exact"
+                  or r.get("signal_reference_source") == "live")
+    n_approximate = sum(1 for r in rows if r.get("signal_reference_source") == "approximate")
+    n_missing = sum(
+        1 for r in rows
+        if r.get("signal_reference_source") in (None, "missing")
+        or r.get("signal_reference_price") is None
+    )
+
+    n_v1 = n_v2 = 0
+    realized_pnl = edge_sum = slip_sum = expected_fee_sum = luck_sum = 0.0
+    realized_fee_sum = fee_luck_sum = 0.0
+    for r in rows:
+        if not include_approximate and r.get("signal_reference_source") == "approximate":
+            continue
+        a = attribute_from_row(r)
+        if a is None:
+            continue
+        realized_pnl += a.realized_pnl
+        edge_sum += a.edge_value
+        slip_sum += a.slip_value
+        expected_fee_sum += a.expected_fee_value
+        luck_sum += a.luck_value
+        realized_fee_sum += a.realized_fee_value
+        fee_luck_sum += a.fee_luck_value
+        if a.model_version_attributed == "v2":
+            n_v2 += 1
+        else:
+            n_v1 += 1
+
+    return AggregateAttribution(
+        n_total=n_total, n_exact=n_exact, n_approximate=n_approximate, n_missing=n_missing,
+        n_v1_attributed=n_v1, n_v2_attributed=n_v2,
+        realized_pnl=realized_pnl, edge_sum=edge_sum, slip_sum=slip_sum,
+        expected_fee_sum=expected_fee_sum, luck_sum=luck_sum,
+        realized_fee_sum=realized_fee_sum, fee_luck_sum=fee_luck_sum,
+    )
+```
+
+### Step 3: Run tests
+
+Run: `pytest tests/test_attribution.py -v`. Expected: all green (8 parametric, 1 intuition, 1 property, 3 row-adapter, 5 aggregator = 18 tests).
+
+### Step 4: Commit
+
+```bash
+git add polypocket/attribution.py tests/test_attribution.py
+git commit -m "feat(attribution): pure 4-component PnL decomposition + aggregator"
+```
+
+**Rollback:** `git revert HEAD`. Module is pure; nothing imports it yet.
+
+---
+
+## Task 4 + Task 5: Thread `signal_reference_price` through executor AND backfill historical rows (one commit, sequenced)
+
+> **Why bundled:** between Tasks 4 and 5 alone, the trades table has live `"live"` rows mixed with old `NULL`-source rows; any aggregate run in that window looks pathological. Running and shipping both in one commit guarantees the data is in a consistent state.
+
+**Files:**
+- Modify: `polypocket/executor.py`
+- Modify: `tests/test_executor.py`
+- Create: `scripts/backfill_signal_reference.py`
+- Create: `tests/test_backfill_signal_reference.py`
+- Create: `scripts/_backfill_signal_reference.md`
+
+### Step 1: Update `execute_paper_trade` and `execute_live_trade`
+
+Both functions currently call `log_trade(..., status=...)`. Extend them to pass `signal.signal_reference_price` and `signal_reference_source="live"`:
+
+In `execute_paper_trade` (around line 237):
+```python
+        trade_id = log_trade(
+            db_path=db_path,
+            ...
+            pnl=pnl,
+            status=status,
+            signal_reference_price=signal.signal_reference_price,
+            signal_reference_source="live",
+        )
+```
+
+In `execute_live_trade` (around line 307): same addition.
+
+**Audit `reconcile_recovered_trade` (executor.py:78–130):** this path can resurrect a stranded fill via `update_trade(..., size=, entry_price=)` on an existing row. It does NOT call `log_trade`, so it cannot set `signal_reference_price` on a newly-discovered trade. Verify by reading: if reconcile creates new trade rows (it doesn't today — only updates existing ones), they must also persist `signal_reference_price`. Today's code only updates rows that were already logged through `execute_live_trade`, which means the reference price is already persisted. Document this assumption in the test below; if `reconcile_recovered_trade` ever starts creating new rows, this assumption breaks.
+
+### Step 2: Add executor test
+
+Add to `tests/test_executor.py`:
+
+```python
+def test_execute_paper_trade_persists_signal_reference_price(tmp_path):
+    from polypocket.ledger import init_db, find_trade_by_window_slug
+    from polypocket.executor import execute_paper_trade
+    from polypocket.signal import Signal
+
+    db = str(tmp_path / "p.db")
+    init_db(db)
+    sig = Signal(side="up", model_p_up=0.72, market_price=0.55, edge=0.12,
+                 up_edge=0.12, down_edge=0.0, signal_reference_price=0.60)
+    res = execute_paper_trade(db, sig, entry_price=0.60, size=10.0,
+                              window_slug="w1", outcome="up")
+    assert res.success
+    row = find_trade_by_window_slug(db, "w1")
+    assert row["signal_reference_price"] == pytest.approx(0.60, abs=1e-9)
+    assert row["signal_reference_source"] == "live"
+```
+
+Run: `pytest tests/test_executor.py -k signal_reference -v`. Expected: green.
+
+### Step 3: Write backfill tests
+
+Create `tests/test_backfill_signal_reference.py`:
+
+```python
+"""Tests for the one-shot signal_reference_price backfill.
+
+Provenance per the design:
+  'exact'        : decision snapshot has the side-relevant non-null bids JSON
+  'approximate'  : decision snapshot exists but lacks the side-relevant bids JSON
+  'missing'      : no decision snapshot for the window
+"""
+import json
+import sqlite3
+
+import pytest
+
+from polypocket.ledger import init_db, log_trade, log_snapshot
+from scripts.backfill_signal_reference import backfill
+
+
+def _seed_trade_and_decision(db, slug, side, has_opp_bids):
+    """has_opp_bids: True populates the bids the given side's gate needs."""
+    log_trade(
+        db_path=db, window_slug=slug, side=side, entry_price=0.60, size=10.0,
+        fees=0.024, model_p_up=0.70, market_p_up=0.58, edge=0.12,
+        outcome="up", pnl=3.976, status="settled",
+    )
+    stats = {"btc_price": 65000, "window_open_price": 64900,
+             "displacement": 0.0015, "sigma_5min": 0.002, "model_p_up": 0.70,
+             "t_remaining": 200, "up_ask": 0.58, "down_ask": 0.42,
+             "market_p_up": 0.58, "edge": 0.12, "preview_side": side,
+             "quote_status": "ok"}
+    book = None
+    if has_opp_bids:
+        # For side='up', the opp side is 'down', so we need down_bids.
+        # For side='down', we need up_bids.
+        book = {"up": [], "down": [],
+                "up_bids": [{"price": 0.42}] if side == "down" else None,
+                "down_bids": [{"price": 0.42}] if side == "up" else None}
+    log_snapshot(db, slug, "decision", stats, book_depth=book)
+
+
+def test_backfill_tags_exact_when_side_relevant_bids_present(tmp_path):
+    from polypocket.config import SIGNAL_CUSHION_TICKS
+
+    db = str(tmp_path / "t.db")
+    init_db(db)
+    _seed_trade_and_decision(db, "w1", "up", has_opp_bids=True)
+    counts = backfill(db)
+    assert counts["exact"] == 1
+    with sqlite3.connect(db) as c:
+        row = c.execute(
+            "SELECT signal_reference_price, signal_reference_source "
+            "FROM trades WHERE window_slug='w1'"
+        ).fetchone()
+    assert row[1] == "exact"
+    expected = (1.0 - 0.42) + SIGNAL_CUSHION_TICKS * 0.01
+    assert row[0] == pytest.approx(expected, abs=1e-9)
+
+
+def test_backfill_tags_approximate_when_opp_bids_missing(tmp_path):
+    db = str(tmp_path / "t.db")
+    init_db(db)
+    _seed_trade_and_decision(db, "w2", "up", has_opp_bids=False)
+    counts = backfill(db)
+    assert counts["approximate"] == 1
+    with sqlite3.connect(db) as c:
+        row = c.execute(
+            "SELECT signal_reference_price, signal_reference_source "
+            "FROM trades WHERE window_slug='w2'"
+        ).fetchone()
+    assert row[1] == "approximate"
+    assert row[0] == pytest.approx(0.58, abs=1e-9)  # falls back to up_ask
+
+
+def test_backfill_tags_missing_when_no_decision_snapshot(tmp_path):
+    db = str(tmp_path / "t.db")
+    init_db(db)
+    log_trade(db_path=db, window_slug="w3", side="up", entry_price=0.6, size=10.0,
+              fees=0.024, model_p_up=0.7, market_p_up=0.58, edge=0.12,
+              outcome="up", pnl=3.976, status="settled")
+    counts = backfill(db)
+    assert counts["missing"] == 1
+    with sqlite3.connect(db) as c:
+        row = c.execute(
+            "SELECT signal_reference_price, signal_reference_source "
+            "FROM trades WHERE window_slug='w3'"
+        ).fetchone()
+    assert row[1] == "missing"
+    assert row[0] is None
+
+
+def test_backfill_is_idempotent(tmp_path):
+    db = str(tmp_path / "t.db")
+    init_db(db)
+    _seed_trade_and_decision(db, "w4", "up", has_opp_bids=True)
+    backfill(db)
+    with sqlite3.connect(db) as c:
+        first = c.execute("SELECT signal_reference_price, signal_reference_source "
+                          "FROM trades WHERE window_slug='w4'").fetchone()
+    counts2 = backfill(db)
+    assert counts2["skipped"] == 1
+    with sqlite3.connect(db) as c:
+        second = c.execute("SELECT signal_reference_price, signal_reference_source "
+                           "FROM trades WHERE window_slug='w4'").fetchone()
+    assert first == second
+
+
+def test_backfill_does_not_overwrite_live_rows(tmp_path):
+    """Rows already tagged 'live' (from a real trade post-Task 4) are left alone."""
+    db = str(tmp_path / "t.db")
+    init_db(db)
+    log_trade(db_path=db, window_slug="w5", side="up", entry_price=0.6, size=10.0,
+              fees=0.024, model_p_up=0.7, market_p_up=0.58, edge=0.12,
+              outcome="up", pnl=3.976, status="settled",
+              signal_reference_price=0.59, signal_reference_source="live")
+    backfill(db)
+    with sqlite3.connect(db) as c:
+        row = c.execute("SELECT signal_reference_price, signal_reference_source "
+                        "FROM trades WHERE window_slug='w5'").fetchone()
+    assert row == (0.59, "live")
+```
+
+Run: `pytest tests/test_backfill_signal_reference.py -v`. Expected: FAIL on `ModuleNotFoundError`.
+
+### Step 4: Implement the backfill
+
+Create `scripts/backfill_signal_reference.py`:
+
+```python
+"""One-shot backfill: compute signal_reference_price for historical trades rows.
+
+Idempotent. Skips rows already tagged (signal_reference_source IS NOT NULL).
+Provenance per row:
+  'exact'        — recomputed from the side-relevant decision-snapshot bids JSON
+  'approximate'  — fell back to decision-snapshot up_ask/down_ask
+  'missing'      — no decision snapshot, or no ask price either
+
+Run with: python scripts/backfill_signal_reference.py [--db PATH]
+Default DB is polypocket.config.PAPER_DB_PATH.
+"""
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from contextlib import closing
+
+from polypocket.config import PAPER_DB_PATH, SIGNAL_CUSHION_TICKS
+
+
+def _effective_entry(ask: float | None, opp_bids: list[dict] | None) -> float | None:
+    if not opp_bids:
+        return ask
+    best_opp = max(float(b["price"]) for b in opp_bids)
+    return min(0.99, (1.0 - best_opp) + SIGNAL_CUSHION_TICKS * 0.01)
+
+
+def _classify_and_compute(
+    side: str, decision: dict | None
+) -> tuple[float | None, str]:
+    if decision is None:
+        return None, "missing"
+    up_bids = json.loads(decision["up_bids_json"]) if decision.get("up_bids_json") else None
+    down_bids = json.loads(decision["down_bids_json"]) if decision.get("down_bids_json") else None
+    if side == "up":
+        opp = down_bids
+        ask = decision.get("up_ask")
+    else:
+        opp = up_bids
+        ask = decision.get("down_ask")
+    if opp:
+        return _effective_entry(ask, opp), "exact"
+    if ask is not None:
+        return float(ask), "approximate"
+    return None, "missing"
+
+
+def backfill(db_path: str) -> dict:
+    """Returns counts: {'exact': N, 'approximate': N, 'missing': N, 'skipped': N}."""
+    counts = {"exact": 0, "approximate": 0, "missing": 0, "skipped": 0}
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        trades = conn.execute(
+            "SELECT id, window_slug, side, signal_reference_source "
+            "FROM trades"
+        ).fetchall()
+        for t in trades:
+            if t["signal_reference_source"] is not None:
+                counts["skipped"] += 1
+                continue
+            decision = conn.execute(
+                "SELECT up_ask, down_ask, up_bids_json, down_bids_json "
+                "FROM window_snapshots "
+                "WHERE window_slug = ? AND snapshot_type = 'decision' "
+                "LIMIT 1",
+                (t["window_slug"],),
+            ).fetchone()
+            decision_dict = dict(decision) if decision is not None else None
+            price, source = _classify_and_compute(t["side"], decision_dict)
+            counts[source] += 1
+            conn.execute(
+                "UPDATE trades SET signal_reference_price = ?, "
+                "signal_reference_source = ? WHERE id = ?",
+                (price, source, t["id"]),
+            )
+        conn.commit()
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill signal_reference_price on trades")
+    parser.add_argument("--db", default=PAPER_DB_PATH)
+    parser.add_argument("--skip-if-missing", action="store_true",
+                        help="No-op (with exit 0) if --db does not exist on disk")
+    args = parser.parse_args()
+    if args.skip_if_missing and not os.path.exists(args.db):
+        print(f"Skipping backfill: {args.db} does not exist")
+        return 0
+    counts = backfill(args.db)
+    print(f"Backfill complete on {args.db}: {counts}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+### Step 5: Run tests
+
+Run: `pytest tests/test_backfill_signal_reference.py tests/test_executor.py -v`. Expected: all green.
+
+### Step 6: Back up the databases before running against real data
+
+Cross-platform (PowerShell on Windows, bash on POSIX):
+
+PowerShell:
+```powershell
+Copy-Item paper_trades.db paper_trades.pre-attrib-backfill.bak.db
+if (Test-Path live_trades.db) { Copy-Item live_trades.db live_trades.pre-attrib-backfill.bak.db }
+```
+
+bash / git-bash:
+```bash
+cp paper_trades.db paper_trades.pre-attrib-backfill.bak.db
+[ -f live_trades.db ] && cp live_trades.db live_trades.pre-attrib-backfill.bak.db
+```
+
+### Step 7: Run the backfill
+
+```bash
+python scripts/backfill_signal_reference.py --db paper_trades.db
+python scripts/backfill_signal_reference.py --db live_trades.db --skip-if-missing
+```
+
+Expected paper output: counts dict where `exact + approximate + missing` equals the row count from Task 0 Step 2, with `exact` close to (but not exceeding) the bids-JSON count captured at Task 0. Approximate is expected to dominate (~70%) per the design's empirical-coverage note.
+
+Sanity-check:
+
+```bash
+sqlite3 paper_trades.db "SELECT signal_reference_source, COUNT(*) FROM trades GROUP BY signal_reference_source"
+```
+
+### Step 8: Write the backfill log
+
+Write `scripts/_backfill_signal_reference.md`:
+
+```markdown
+# Signal-reference backfill log
+
+**Date:** YYYY-MM-DD
+**SIGNAL_CUSHION_TICKS at backfill time:** 8
+**Task 0 baseline (paper):**
+  MAX(trades.id) = N_PRE
+  COUNT(settled trades) = M_PRE
+  bids-JSON-populated decision rows = K_PRE / TOTAL_DECISION_PRE
+
+## Paper DB
+| source | count |
+| --- | --- |
+| exact | N |
+| approximate | N |
+| missing | N |
+| skipped (already tagged) | N |
+
+## Live DB
+[same table or "DB did not exist; skipped"]
+
+## Notes
+- Approximate rows under-count slippage by the average pair-merge wedge;
+  excluded from headline aggregates per design.
+- A re-run is a no-op (skipped count == row count).
+- Task 10 Step 4's forward-soak boundary is MAX(trades.id) = N_PRE.
+```
+
+Fill `N_PRE` / `M_PRE` / `K_PRE` / `TOTAL_DECISION_PRE` from the file written in Task 0 Step 2.
+
+### Step 9: Commit
+
+```bash
+git add polypocket/executor.py tests/test_executor.py \
+        scripts/backfill_signal_reference.py tests/test_backfill_signal_reference.py \
+        scripts/_backfill_signal_reference.md
+git commit -m "feat(attribution): persist signal_reference_price live + backfill history"
+```
+
+**Rollback:** `git revert HEAD` reverts code. To restore DB state, copy the `.bak.db` files back over `paper_trades.db` / `live_trades.db`. The backfill writes only to the two new columns, but DB snapshots are cheap insurance.
+
+---
+
+## Task 6: Wire attribution into `analyze.py`
+
+**Files:**
+- Modify: `polypocket/analyze.py`
+
+### Step 1: Add Section 7 to `generate_report`
+
+In `polypocket/analyze.py`, after the existing reliability section, add:
+
+```python
+    # ================================================================
+    h2("7. PnL Attribution")
+    # ================================================================
+
+    from polypocket.attribution import aggregate_attribution
+
+    agg_lifetime = aggregate_attribution(settled)
+    agg_lifetime_all = aggregate_attribution(settled, include_approximate=True)
+    agg_last20 = aggregate_attribution(settled[-20:]) if settled else None
+
+    def _fmt_agg(label, a) -> list:
+        if a is None or a.n_total == 0:
+            return [label, "--", "--", "--", "--", "--", "--", "--"]
+        return [
+            label, a.n_total,
+            f"${a.realized_pnl:+.2f}",
+            f"${a.edge_sum:+.2f}",
+            f"${a.slip_sum:+.2f}",
+            f"${a.expected_fee_sum:+.2f}",
+            f"${a.luck_sum:+.2f}",
+            f"${a.fee_luck_sum:+.2f}",
+        ]
+
+    p("**Headline (exact + live rows only)** — `approximate` rows excluded "
+      "because their slip is biased toward zero (see design doc).")
+    table(
+        ["Window", "N", "Realized", "Edge", "Slip", "Exp.Fee", "Luck", "Fee-luck"],
+        [
+            _fmt_agg("Lifetime", agg_lifetime),
+            _fmt_agg("Last 20", agg_last20),
+        ],
+    )
+    p(f"**Context (all rows incl. approximate):** "
+      f"realized=${agg_lifetime_all.realized_pnl:+.2f}, "
+      f"edge=${agg_lifetime_all.edge_sum:+.2f}, "
+      f"slip=${agg_lifetime_all.slip_sum:+.2f}")
+    p(f"**Provenance:** exact/live={agg_lifetime.n_exact}, "
+      f"approximate={agg_lifetime.n_approximate}, "
+      f"missing={agg_lifetime.n_missing}")
+    p(f"**Model cohort:** v1-attributed={agg_lifetime.n_v1_attributed}, "
+      f"v2-attributed={agg_lifetime.n_v2_attributed}")
+```
+
+### Step 2: Smoke test on the actual DB
+
+Run the report:
+
+```bash
+python -c "from polypocket.analyze import generate_report; print(generate_report('paper_trades.db'))" > /tmp/report.md
+```
+
+Expected: report includes a "7. PnL Attribution" section with non-empty numbers and both headline and context lines. Sanity: `Realized` in the context (all rows) equals the sum of `pnl` from settled trades where `signal_reference_source` is not `"missing"` and `pnl` is not NULL.
+
+### Step 3: Commit
+
+```bash
+git add polypocket/analyze.py
+git commit -m "feat(analyze): add PnL attribution section to report"
+```
+
+**Rollback:** `git revert HEAD`.
+
+---
+
+## Task 7: Add `AttributionPanel` to the TUI (with a unit-testable render function)
+
+**Files:**
+- Modify: `polypocket/tui.py`
+- Add test: `tests/test_attribution.py` (extend) OR `tests/test_tui_attribution.py`
+
+### Step 1: Extract a pure render function
+
+In `polypocket/tui.py`, define:
+
+```python
+def render_attribution_text(db_path: str) -> str:
+    """Pure function: read settled trades, render the TUI panel body as text.
+
+    Factored out of AttributionPanel so it can be unit-tested without
+    instantiating textual widgets.
+    """
+    import sqlite3
+    from contextlib import closing
+    from polypocket.attribution import aggregate_attribution
+
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        all_settled = [dict(r) for r in conn.execute(
+            "SELECT * FROM trades WHERE status='settled' ORDER BY id"
+        ).fetchall()]
+
+    last20 = all_settled[-20:]
+    agg_life = aggregate_attribution(all_settled)
+    agg_20 = aggregate_attribution(last20)
+
+    def fmt(a):
+        return (f"R ${a.realized_pnl:+7.2f}  "
+                f"E ${a.edge_sum:+7.2f}  "
+                f"S ${a.slip_sum:+7.2f}  "
+                f"F ${a.expected_fee_sum:+7.2f}  "
+                f"L ${a.luck_sum:+7.2f}")
+
+    lines = ["[bold]PNL ATTRIBUTION (exact/live only)[/bold]", ""]
+    lines.append(f"Lifetime (n={agg_life.n_total}):")
+    lines.append(f"  {fmt(agg_life)}")
+    lines.append("")
+    lines.append(f"Last 20 (n={agg_20.n_total}):")
+    lines.append(f"  {fmt(agg_20)}")
+    lines.append("")
+    lines.append(f"Provenance: exact/live={agg_life.n_exact} "
+                 f"approx={agg_life.n_approximate} missing={agg_life.n_missing}")
+    lines.append(f"Cohort: v1={agg_life.n_v1_attributed} v2={agg_life.n_v2_attributed}")
+    return "\n".join(lines)
+
+
+class AttributionPanel(Static):
+    def update_attribution(self, db_path: str) -> None:
+        self.update(render_attribution_text(db_path))
+```
+
+### Step 2: Mount the panel
+
+Locate the existing `compose()` in `PolypocketApp` (the textual app class). Add `AttributionPanel(id="attribution-panel")` to the layout next to `StatusPanel`. Hook its `update_attribution(db_path)` call into the same refresh path that calls `StatusPanel.update_stats(...)`.
+
+### Step 3: Write a render-function test
+
+Append to `tests/test_attribution.py` (or create `tests/test_tui_attribution.py` if preferred):
+
+```python
+def test_render_attribution_text_handles_empty_db(tmp_path):
+    """Empty DB renders without errors; counts read zero."""
+    from polypocket.ledger import init_db
+    from polypocket.tui import render_attribution_text
+
+    db = str(tmp_path / "empty.db")
+    init_db(db)
+    text = render_attribution_text(db)
+    assert "PNL ATTRIBUTION" in text
+    assert "Lifetime (n=0)" in text
+
+
+def test_render_attribution_text_with_seeded_trades(tmp_path):
+    """Realized numbers in the rendered text match the trades.pnl sum."""
+    from polypocket.ledger import init_db, log_trade
+    from polypocket.tui import render_attribution_text
+
+    db = str(tmp_path / "seeded.db")
+    init_db(db)
+    log_trade(db_path=db, window_slug="w1", side="up", entry_price=0.60, size=10.0,
+              fees=0.024, model_p_up=0.70, market_p_up=0.58, edge=0.12,
+              outcome="up", pnl=3.976, status="settled",
+              signal_reference_price=0.58, signal_reference_source="exact")
+    text = render_attribution_text(db)
+    assert "+3.98" in text  # realized PnL formatted to 2dp
+```
+
+Run: `pytest tests/test_attribution.py -v`. Expected: green.
+
+### Step 4: Smoke test the TUI
+
+```bash
+python -m polypocket.tui
+```
+
+Expected: panel renders, numbers match those in the analyze.py report from Task 6. Quit with `q` or Ctrl+C.
+
+### Step 5: Commit
+
+```bash
+git add polypocket/tui.py tests/test_attribution.py
+git commit -m "feat(tui): add PnL attribution panel + render-function test"
+```
+
+**Rollback:** `git revert HEAD`.
+
+---
+
+## Task 8: Weekly attribution report script
+
+**Files:**
+- Create: `scripts/pnl_attribution_report.py`
+- Update `.gitignore` to exclude generated report
+- Commit one sample artifact
+
+### Step 1: Implement the report generator
+
+Create `scripts/pnl_attribution_report.py`:
+
+```python
+"""Generate scripts/_pnl_attribution.md from the live + paper ledgers.
+
+Run manually or from cron; idempotent (overwrites the output file).
+"""
+import argparse
+import os
+import sqlite3
+import sys
+from contextlib import closing
+from datetime import datetime, timezone
+from pathlib import Path
+
+from polypocket.attribution import aggregate_attribution
+from polypocket.config import LIVE_DB_PATH, PAPER_DB_PATH
+
+
+def _load_settled(db_path: str) -> list[dict]:
+    if not os.path.exists(db_path):
+        return []
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        return [dict(r) for r in conn.execute(
+            "SELECT * FROM trades WHERE status='settled' ORDER BY id"
+        ).fetchall()]
+
+
+def _section(name: str, rows: list[dict]) -> list[str]:
+    out = [f"## {name}\n"]
+    if not rows:
+        out.append("_no settled trades (or DB does not exist)_\n")
+        return out
+    agg_life = aggregate_attribution(rows)
+    agg_life_all = aggregate_attribution(rows, include_approximate=True)
+    agg_100 = aggregate_attribution(rows[-100:])
+    agg_20 = aggregate_attribution(rows[-20:])
+    out.append("**Headline (exact/live only):**\n")
+    out.append("| Window | N | Realized | Edge | Slip | Exp.Fee | Luck | Fee-luck |")
+    out.append("| --- | --- | --- | --- | --- | --- | --- | --- |")
+    for label, a in [("Lifetime", agg_life), ("Last 100", agg_100), ("Last 20", agg_20)]:
+        out.append(
+            f"| {label} | {a.n_total} | ${a.realized_pnl:+.2f} | ${a.edge_sum:+.2f} | "
+            f"${a.slip_sum:+.2f} | ${a.expected_fee_sum:+.2f} | ${a.luck_sum:+.2f} | "
+            f"${a.fee_luck_sum:+.2f} |"
+        )
+    out.append("")
+    out.append(
+        f"**Context (all rows incl. approximate):** lifetime "
+        f"realized=${agg_life_all.realized_pnl:+.2f}, edge=${agg_life_all.edge_sum:+.2f}, "
+        f"slip=${agg_life_all.slip_sum:+.2f}\n"
+    )
+    out.append(
+        f"**Provenance:** exact/live={agg_life.n_exact}, "
+        f"approximate={agg_life.n_approximate}, missing={agg_life.n_missing}\n"
+    )
+    out.append(
+        f"**Model cohort:** v1-attributed={agg_life.n_v1_attributed}, "
+        f"v2-attributed={agg_life.n_v2_attributed}\n"
+    )
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", default="scripts/_pnl_attribution.md")
+    args = parser.parse_args()
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    paper = _load_settled(PAPER_DB_PATH)
+    live = _load_settled(LIVE_DB_PATH)
+
+    lines = [f"# PnL Attribution Report -- {now}\n"]
+    lines += _section("Paper", paper)
+    lines += _section("Live", live)
+
+    Path(args.out).write_text("\n".join(lines))
+    print(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+### Step 2: Decide what to commit
+
+The report regenerates frequently. Two precedents in the repo:
+- `scripts/_model_v2_paper_ab.md` — committed once as a reference artifact, not regenerated in CI.
+- Most ad-hoc `analyze.py` output — gitignored.
+
+Adopted policy: commit the **first generated artifact** as `scripts/_pnl_attribution.md` so it's discoverable; add the path to `.gitignore` to suppress noisy diffs on subsequent regenerations. If a future change to the report format warrants an updated reference, re-add and commit explicitly.
+
+Update `.gitignore`:
+
+```
+# Generated PnL attribution reports (committed sample is whitelisted on first run only).
+scripts/_pnl_attribution.md
+```
+
+### Step 3: Generate the first report and force-add the sample
+
+```bash
+python scripts/pnl_attribution_report.py
+git add -f scripts/_pnl_attribution.md  # bypass .gitignore for the one-time sample
+```
+
+### Step 4: Commit
+
+```bash
+git add scripts/pnl_attribution_report.py .gitignore scripts/_pnl_attribution.md
+git commit -m "feat(scripts): weekly PnL attribution report generator"
+```
+
+**Rollback:** `git revert HEAD`. Re-runs do not pollute git status thanks to `.gitignore`.
+
+---
+
+## Task 9: Hand-replay reference trades
+
+**Files:**
+- Create: `scripts/_pnl_attribution_reference.md`
+
+### Step 1: Pick three trades
+
+From `paper_trades.db`, query for representative rows. Restrict to `exact` or `live` provenance — `approximate` rows are not suitable references because their slip is biased.
+
+```bash
+sqlite3 paper_trades.db "SELECT id, window_slug, side, entry_price, signal_reference_price, model_p_up, fees, outcome, pnl FROM trades WHERE status='settled' AND signal_reference_source IN ('exact', 'live') ORDER BY ABS(entry_price - signal_reference_price) DESC LIMIT 5"
+```
+
+Pick the highest-slip row. Then a low-slip win and a low-slip loss:
+
+```bash
+sqlite3 paper_trades.db "SELECT id, window_slug, side, entry_price, signal_reference_price, model_p_up, fees, outcome, pnl FROM trades WHERE status='settled' AND signal_reference_source IN ('exact', 'live') AND ABS(entry_price - signal_reference_price) < 0.005 AND outcome = side ORDER BY id DESC LIMIT 3"
+sqlite3 paper_trades.db "SELECT id, window_slug, side, entry_price, signal_reference_price, model_p_up, fees, outcome, pnl FROM trades WHERE status='settled' AND signal_reference_source IN ('exact', 'live') AND ABS(entry_price - signal_reference_price) < 0.005 AND outcome != side ORDER BY id DESC LIMIT 3"
+```
+
+### Step 2: Hand-compute each one
+
+For each chosen trade, write the math step-by-step in `scripts/_pnl_attribution_reference.md`:
+
+```markdown
+# PnL attribution reference trades (regression artifact)
+
+For each trade, the math is recomputed by hand using the algebra in
+`docs/plans/2026-05-11-pnl-attribution-design.md`. realized_pnl is taken
+directly from trades.pnl (not recomputed). These serve as a regression
+artifact: if `attribution.py` ever drifts from the design, re-running it
+against these trades should reproduce these numbers to abs_tol=1e-6.
+
+## Trade 1 — clean win (window_slug=...)
+- side=up, size=..., entry_price=..., signal_ref=..., model_p_up=..., fees=..., outcome=up
+- trades.pnl = ... (authoritative realized_pnl)
+- edge_value = size*(model_p_up - signal_ref) = ...
+- slip_value = size*(signal_ref - entry_price) = ...
+- expected_fee_value = -fees*model_p_up = ...
+- luck_value = trades.pnl - (edge + slip + exp_fee) = ...
+- Sum check: edge + slip + exp_fee + luck = ... ≈ trades.pnl ✓
+
+## Trade 2 — clean loss ...
+## Trade 3 — high-slip fill ...
+```
+
+### Step 3: Verify by running attribution.py
+
+```bash
+python -c "
+import math
+import sqlite3
+from polypocket.attribution import attribute_from_row
+with sqlite3.connect('paper_trades.db') as c:
+    c.row_factory = sqlite3.Row
+    for slug in ['SLUG_1', 'SLUG_2', 'SLUG_3']:
+        r = dict(c.execute('SELECT * FROM trades WHERE window_slug=?', (slug,)).fetchone())
+        a = attribute_from_row(r)
+        print(slug, a)
+"
+```
+
+Compare each component against hand-computed values. Each `|actual − expected| < 1e-6` per `math.isclose(..., abs_tol=1e-6)`.
+
+### Step 4: Commit
+
+```bash
+git add scripts/_pnl_attribution_reference.md
+git commit -m "docs(scripts): reference PnL attributions for 3 trades (regression artifact)"
+```
+
+---
+
+## Task 10: Verification and closeout
+
+### Step 1: Full test run
+
+```bash
+pytest -v
+```
+
+Expected: full suite green, including all new tests.
+
+### Step 2: Verify aggregate sanity on paper DB (exact/live rows only)
+
+```bash
+python -c "
+import sqlite3
+from polypocket.attribution import aggregate_attribution
+with sqlite3.connect('paper_trades.db') as c:
+    c.row_factory = sqlite3.Row
+    rows = [dict(r) for r in c.execute(
+        \"SELECT * FROM trades WHERE status='settled' AND signal_reference_source IN ('exact', 'live') AND pnl IS NOT NULL\"
+    ).fetchall()]
+realized_from_pnl = sum(r['pnl'] for r in rows)
+agg = aggregate_attribution(rows)
+print(f'realized_from_pnl_column = {realized_from_pnl:.6f}')
+print(f'realized_from_attribution = {agg.realized_pnl:.6f}')
+print(f'diff = {realized_from_pnl - agg.realized_pnl:.2e}')
+"
+```
+
+Expected: `diff` < 1e-6 USDC. (Definitionally true since `realized_pnl` is `trades.pnl`; this check guards against type-coercion bugs and dropped rows.)
+
+### Step 3: Live DB — report the divergence, do not gate on it
+
+If `live_trades.db` exists, the same check on live rows is expected to be tighter than 1e-6 because every live row also has `signal_reference_source='live'`. But the design's risk #2 notes that `luck_value` on live rows absorbs the algebra-vs-CLOB accounting residual; this affects per-component sums, not the realized sum. Report observed live numbers, do not assert.
+
+```bash
+[ -f live_trades.db ] && python -c "
+import sqlite3
+from polypocket.attribution import aggregate_attribution
+with sqlite3.connect('live_trades.db') as c:
+    c.row_factory = sqlite3.Row
+    rows = [dict(r) for r in c.execute(
+        \"SELECT * FROM trades WHERE status='settled' AND pnl IS NOT NULL\"
+    ).fetchall()]
+print(aggregate_attribution(rows))
+"
+```
+
+### Step 4: Verify the report regenerates cleanly
+
+```bash
+python scripts/pnl_attribution_report.py
+```
+
+Expected: writes `scripts/_pnl_attribution.md` without errors. `git status` shows the file as gitignored / not in working-tree diffs (post-Task 8 Step 2).
+
+### Step 5: 7-day forward-soak check (deferred, runs naturally)
+
+After 7 days of operation post-shipping, verify all newly settled trades have `signal_reference_source = "live"` and non-NULL `signal_reference_price`. Read `MAX(id)` baseline from `scripts/_backfill_signal_reference.md` (Task 5 Step 8 captured it).
+
+```bash
+# Replace N_PRE with the value from _backfill_signal_reference.md
+sqlite3 paper_trades.db "SELECT COUNT(*) FROM trades WHERE status='settled' AND id > N_PRE AND signal_reference_source != 'live'"
+```
+
+Expected: `0`. If non-zero, investigate which path created a trade row without populating `signal_reference_price` (likely candidates: `reconcile_recovered_trade`, a new test seed, or a regression in `signal.py`).
+
+### Step 6: Final state check
+
+```bash
+git status   # should be clean
+git log --oneline | head -10
+```
+
+Confirm the commit chain shows the task commits in order: ledger, signal, attribution, executor+backfill (bundled), analyze, tui, report, reference, [optional cleanup].
+
+---
+
+## Definition of Done (from design doc, mirrored here)
+
+- [x] `trades.signal_reference_price` + `trades.signal_reference_source` columns shipped (Task 1).
+- [x] `polypocket/attribution.py` with full test coverage including aggregator (Task 3).
+- [x] `signal.py` / `executor.py` / `ledger.py` plumbing committed (Tasks 2, 4+5).
+- [x] Backfill script run; log committed with Task 0 baseline numbers (Task 5).
+- [x] `analyze.py` Section 7 shipped with headline + context lines (Task 6).
+- [x] `AttributionPanel` mounted in TUI with a unit-testable render function (Task 7).
+- [x] Weekly report generator + sample artifact committed; subsequent regenerations gitignored (Task 8).
+- [x] Hand-replay reference trades committed (Task 9).
+- [x] Full test suite green; aggregate sanity verified on paper to `< 1e-6 USDC`; live divergence reported, not gated (Task 10).
+- [ ] 7-day forward-soak shows 100% `"live"` provenance on new trades (Task 10 Step 5, deferred).


### PR DESCRIPTION
## Summary
- Paired design + implementation plan for the 4-component PnL decomposition (edge / slip / expected_fee / luck) called for in 2026-05-11 brainstorm Idea #41.
- Two adversarial review passes baked in: the second pass surfaced 13 new findings (signal-test inputs that didn't fire, v1/v2 cohort inference reading a non-existent trades column, IOC partial-fill path contradicting the design's FOK assumption, conftest gap on SIGNAL_CUSHION_TICKS, edge-vs-effective_ask interpretation, sort-order disagreement, aggregator count inconsistency, cross-platform paths, stranded-fill drift, scope creep in the Artifact section, phantom 9th test case, mis-labeled realized_fee semantics, Task 0 baseline predicate). All 13 patched into the plan before merge.
- No code changes — docs only. Implementation is the next PR.

## Test plan
- [ ] Verify the plan reads coherently end-to-end (acceptance criteria, task numbering, file paths cross-reference)
- [ ] On merge, kick off implementation in a fresh chat following Task 0 → Task 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)