### PR TITLE
feat: migrate to py-clob-client-v2 after CLOB v2 cutover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ corpus*.parquet
 
 # Generated PnL attribution reports (committed sample is whitelisted on first run only).
 scripts/_pnl_attribution.md
+
+# Throwaway probe scripts — never commit.
+scripts/_probe_*.py

--- a/docs/plans/2026-05-15-clob-v2-migration-design.md
+++ b/docs/plans/2026-05-15-clob-v2-migration-design.md
@@ -1,0 +1,159 @@
+# CLOB v2 SDK migration — design
+
+## Problem
+
+Polymarket completed their CLOB v2 server migration on 2026-04-28. The
+EIP-712 Exchange domain version bumped from `"1"` to `"2"`; legacy V1 SDKs
+sign with the old version and every order is rejected by the server with
+HTTP 400 `{"error": "order_version_mismatch"}`. We're pinned to
+`py-clob-client==0.19.0`, so since the cutover every order this bot has
+ever signed has been server-rejected. Confirmed empirically on the
+2026-05-15 live session: 4 gate-passing decisions, 4 `order_version_mismatch`
+rejects, 0 fills.
+
+Resolution path per Polymarket's [migration changelog entry][changelog]
+and the [v2 SDK reference][sdks] is to install `py-clob-client-v2` and
+remove the legacy package. The new SDK changes the import surface, the
+order constructors, the order-type enum, the cancel API, and removes
+client-side fee handling.
+
+In parallel, the v1 → v2 contract swap means our previous on-chain
+allowances against the V1 Exchange contracts are dead; the user has
+already manually migrated USDC.e → pUSD and re-approved allowances against
+the V2 CTF Exchange (`0xE111180000d2663C0091e4f400237545B87B996B`) and
+Neg Risk CTF Exchange (`0xe2222d279d744050d28e00520010520000310F59`).
+That work is out of scope here; this plan is the SDK-level code work that
+follows.
+
+[changelog]: https://docs.polymarket.com/changelog
+[sdks]: https://docs.polymarket.com/api-reference/clients-sdks.md
+
+## Goal
+
+Get `TRADING_MODE=live` back to a working state: orders sign with the v2
+domain, the bot's `submit_fok` / `submit_ioc` paths still satisfy the
+`LiveOrderClient` protocol in `executor.py`, settlement accounting in
+`get_settlement_info` ties out, and the existing reconciler / stranded-fill
+sweep keeps working.
+
+## V1 → V2 API deltas (verified against official docs + v2 source)
+
+| Concern | v1 (`py_clob_client` 0.19.0) | v2 (`py_clob_client_v2` 1.0.1) |
+|---|---|---|
+| Package | `py-clob-client` | `py-clob-client-v2` |
+| Imports | `py_clob_client.client.ClobClient` | `py_clob_client_v2.ClobClient` |
+| Imports — types | `py_clob_client.clob_types.{ApiCreds,AssetType,BalanceAllowanceParams,MarketOrderArgs,OrderType,TradeParams}` | `py_clob_client_v2.{ApiCreds,AssetType,BalanceAllowanceParams,MarketOrderArgs,OrderType,TradeParams,PartialCreateOrderOptions,OrderPayload,Side,SignatureTypeV2}` |
+| `ClobClient.__init__` | `host, key, chain_id, creds, signature_type, funder` | same kwargs; pass `SignatureTypeV2.POLY_PROXY` (= 1) for clarity instead of the literal `1` |
+| Order placement | `client.create_market_order(args)` → `client.post_order(signed, OrderType.FOK)` | single call: `client.create_and_post_market_order(args, options=PartialCreateOrderOptions(tick_size="0.01"), order_type=OrderType.FOK)`; built-in `_retry_on_version_update` |
+| `MarketOrderArgs` fields | `token_id, amount, price, fee_rate_bps` (no `side`, no `order_type`) | `token_id, amount, side, price, order_type, user_usdc_balance, builder_code, metadata` — `side` and `order_type` **required** (with defaults); `fee_rate_bps` **gone** (server computes per [fees docs][fees]) |
+| `Side` | string `"BUY"/"SELL"` literals | `Side` IntEnum (`BUY=0, SELL=1`) |
+| `OrderType` enum | `GTC, FOK, IOC` | `GTC, FOK, FAK, GTD` — **no IOC**; FAK is the new "fill what you can, kill rest" |
+| `tick_size` | implicit | per-call via `PartialCreateOrderOptions(tick_size="0.01")` |
+| Cancel | `client.cancel(order_id=str)` | `client.cancel_order(payload=OrderPayload(orderID=str))` (verified in v2 `client.py`; docs example still shows the legacy `client.cancel(order_id=...)` form — may be a docs lag, we use the `OrderPayload` form from source) |
+| `BalanceAllowanceParams` | `asset_type, signature_type` | same (now Optional defaults) |
+| `TradeParams(id=tid)` | same | same |
+| `get_market(condition_id)` | returns `taker_base_fee` etc. | still present; we no longer need it for fees |
+| Order owner | `creds.api_key` | `creds.api_key` (unchanged) |
+| Response shape | `success, status, orderID, errorMsg` | `success, orderID, status (live|matched|delayed), makingAmount, takingAmount, transactionsHashes, tradeIDs, errorMsg` per [POST /order][post-order] — superset of v1, our existing predicate `resp.get("success") and resp.get("status") == "matched"` still works unchanged |
+
+[fees]: https://docs.polymarket.com/trading/fees.md
+[post-order]: https://docs.polymarket.com/api-reference/trade/post-a-new-order.md
+
+Material consequences:
+
+- **`submit_ioc` simplifies dramatically.** v1 lacked native IOC, so we
+  posted a `GTC` and hand-rolled a true-IOC by checking `size_matched`
+  and cancelling the remainder, with a pessimistic-estimate fallback for
+  the indexing-race case. v2's `FAK` does this natively; we make one
+  call and read settlement from `/trades`. The `get_order`/`cancel_order`/
+  degraded-estimate paths in our current `submit_ioc` go away.
+- **`_fee_rate_bps_cache` becomes dead code.** v2 manages fees server-side.
+  Delete `_fee_rate_bps()` and its cache field.
+- **`_tick_safe_size` workaround**: keep for now. The v1 bug was a
+  float-based `round_down` in `py_clob_client.order_utils`; v2 has a
+  rewritten order builder. Probably no longer needed, but defense-in-depth
+  is cheap and the workaround is independent of SDK version semantics.
+  Mark as a follow-up candidate to remove.
+- **Pair-merge limit math (`ioc_limit_price`, `fok_limit_price`) stays put.**
+  This is our edge-gate cushion logic against pair-merge clearing prices,
+  not SDK behavior. No SDK migration touches it.
+
+## Things still uncertain — to verify during execution (not blockers)
+
+1. `cancel_order` API: docs show `client.cancel(order_id=str)`, v2 source
+   shows `client.cancel_order(OrderPayload)`. Both probably exist
+   (alias). We use the `OrderPayload` form from the source-of-truth; if
+   it's actually wrong we get an `AttributeError` at import or call
+   time, trivial to fix.
+2. `get_balance_allowance` response numeric scale: v1 returned `balance`
+   as a raw 6-decimal string (`/1_000_000` → USDC). pUSD is a
+   USDC-backed ERC-20 on Polygon; almost certainly also 6 decimals, but
+   we'll log the raw response on first live probe and confirm before
+   trusting the divisor.
+3. `get_order` response still includes `size_matched` and
+   `associate_trades` (required by `get_settlement_info`). The /order
+   endpoint shape isn't documented to have changed, but we'll verify on
+   the probe.
+4. `MarketOrderArgsV2.amount` interpretation: docs say `BUY orders: $$$
+   Amount to buy` (matches v1 USDC-budget semantics, what we pass as
+   `round(size * price, 2)`). Verify against a real fill that
+   `info.shares_held × info.cost_usdc / info.shares_held` ties out to
+   our expected `size`.
+
+## Out of scope
+
+- Migrating to POLY_1271 (deposit wallets). The auth docs explicitly say
+  existing POLY_PROXY users *"can keep using their current funder
+  address and signature type"*. We stay on `signature_type=1`.
+- Builder code attribution (`builder_code` field on `MarketOrderArgsV2`).
+  We're not a builder.
+- `user_usdc_balance` fee adjustment on `MarketOrderArgsV2`. Optional;
+  used to slightly improve fill quality when buying with most-of-balance.
+  Skip — we're sizing small ($5–$20) against >$100 balances, the
+  adjustment is negligible.
+- Sell-side support. We never `Side.SELL`; we only buy outcome tokens
+  at decision time and let them settle to 0 or 1.
+- Migrating the one-off probe scripts (`probe_gtc_cancel.py`,
+  `probe_pair_merge_limit.py`). Used historically for diagnosis; not on
+  the live path.
+
+## Files changed
+
+| File | Type of change |
+|---|---|
+| `pyproject.toml` | swap `py-clob-client==0.19.0` → `py-clob-client-v2==1.0.1` |
+| `polypocket/clients/polymarket.py` | full rewrite of import block, client init signature args, `submit_fok`, `submit_ioc`, `cancel_order`, drop `_fee_rate_bps_cache` + `_fee_rate_bps`, keep `fok_limit_price`/`ioc_limit_price`/`_tick_safe_size`/`get_settlement_info`/`get_usdc_balance`/`get_order_status` largely unchanged |
+| `tests/test_polymarket_client.py` | re-point mocks: `inst.create_market_order` + `inst.post_order` → `inst.create_and_post_market_order`; `inst.cancel` → `inst.cancel_order`; drop `fee_rate_bps` assertions; update response shapes where needed |
+| `scripts/diagnose_live_auth.py` | swap imports + use v2 `SignatureTypeV2` enum |
+| `scripts/derive_clob_creds.py` | swap imports + `create_or_derive_api_key` path |
+| `scripts/check_stranded_fills.py` | swap imports (only) — uses our `PolymarketClient` wrapper, not the SDK directly, so likely no further change |
+
+Out of touch: `polypocket/bot.py`, `polypocket/__main__.py`, `polypocket/executor.py`. They depend only on our `PolymarketClient` wrapper and the `LiveOrderClient` protocol. The protocol signatures don't change; the implementation does.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| v2 `cancel_order(OrderPayload)` form is wrong → `AttributeError` | Smoke-call from a REPL before code-rewrite; flip to `client.cancel(order_id=...)` if the source-of-truth form fails |
+| `get_balance_allowance` numeric scale changes under pUSD → balance gate reads wrong | Log raw response on first live probe; only trust `/1_000_000` divisor after confirming |
+| `MarketOrderArgsV2.amount` semantics differ from v1 → over- or under-spend | First live probe is min-size single FOK; compare cost_usdc from `/trades` against the `amount` we sent; halt if mismatch > 1¢ |
+| FAK partial fill returns no `tradeIDs` in response → settlement lookup races | Existing settlement-lookup flow is post-fill (queries `/trades` by `associate_trades`), unchanged; the v1 degraded-estimate path was only for the GTC-then-cancel race, which no longer exists with native FAK |
+| v2 SDK's built-in `_retry_on_version_update` interferes with our error handling | The retry only fires on `order_version_mismatch`; if we ever see one post-migration it's a real bug — retry semantics are fine |
+| Allowance still wrong despite manual migration → orders reject with `insufficient allowance` rather than `order_version_mismatch` | First live probe is single trade; reject reason will be clear; user's manual migration is asserted by them but trust-but-verify |
+
+## Acceptance bar
+
+1. `pytest tests/` green after the rewrite.
+2. Bot starts in `TRADING_MODE=paper` without import-time crash; one
+   complete decision/close cycle logs into `window_snapshots`.
+3. One hand-crafted FOK probe (min-size, against the real production
+   CLOB, sig_type=1, our funder) returns `success: true,
+   status: "matched"`; `get_settlement_info` returns
+   `shares_held > 0` and `cost_usdc` within 1¢ of the submitted
+   USDC-budget × VWAP.
+4. `TRADING_MODE=live` for 3–5 windows: any gate-passing trade fills (no
+   `order_version_mismatch`, no `insufficient allowance`, no
+   `network: PolyApiException` errors with status 400). Settlement on
+   resolution writes non-null `pnl` per `settle_live_trade`.
+
+Only after #4 do we leave the bot running unattended.

--- a/docs/plans/2026-05-15-clob-v2-migration-implementation.md
+++ b/docs/plans/2026-05-15-clob-v2-migration-implementation.md
@@ -1,0 +1,613 @@
+# CLOB v2 SDK migration — implementation
+
+Companion to `2026-05-15-clob-v2-migration-design.md`. Linear, in-chat
+execution — each step is a single concrete action. No subagent dispatch.
+
+## Pre-flight
+
+User has confirmed:
+- Bot is stopped.
+- USDC.e → pUSD balance manually migrated on funder `0xc84aD1…4C13`.
+- Allowances set (assumed; will be verified empirically on Step 9).
+
+Worktree status going in:
+
+```
+M polypocket/config.py            (MAX_DAILY_LOSS 50 → 15, unrelated to this work)
+M scripts/_pnl_attribution.md     (unrelated)
+M tests/test_config.py            (unrelated)
+?? docs/project-context.md        (unrelated)
+?? scripts/_probe_allowances.py   (unrelated)
+```
+
+These pre-existing edits stay; the v2 migration will touch additional
+files. Branch off main to keep this isolated.
+
+## Step 1 — Branch + dep swap
+
+```powershell
+git checkout -b feat/clob-v2-migration
+```
+
+In `pyproject.toml`, replace the single line:
+
+```
+    "py-clob-client==0.19.0",
+```
+
+with:
+
+```
+    "py-clob-client-v2==1.0.1",
+```
+
+Then:
+
+```powershell
+pip install -e .
+```
+
+Confirm:
+
+```powershell
+python -c "import py_clob_client_v2; print(py_clob_client_v2.__file__)"
+python -c "from py_clob_client_v2 import ClobClient, SignatureTypeV2, OrderType, OrderPayload, MarketOrderArgs, PartialCreateOrderOptions, Side; print('imports ok')"
+```
+
+If either line errors, stop and resolve before proceeding.
+
+Sanity probe — what does v2 actually expose for cancellation:
+
+```powershell
+python -c "from py_clob_client_v2 import ClobClient; c = [a for a in dir(ClobClient) if 'cancel' in a.lower()]; print(c)"
+```
+
+Expect to see `cancel_order` for sure; note whether `cancel` is also
+present as an alias. The implementation in Step 3 uses `cancel_order`;
+flip if needed.
+
+## Step 2 — Backup `live_trades.db`
+
+```powershell
+Copy-Item live_trades.db "live_trades.pre-v2-sdk-20260515.bak.db"
+```
+
+(The existing `live_trades.pre-v2-flip-20260515.bak.db` is the model-v2
+flip backup, distinct from this SDK swap.)
+
+## Step 3 — Rewrite `polypocket/clients/polymarket.py`
+
+Single complete rewrite. Skeleton:
+
+### Import block
+
+```python
+import logging
+import math
+import time
+
+from py_clob_client_v2 import (
+    ApiCreds,
+    AssetType,
+    BalanceAllowanceParams,
+    ClobClient,
+    MarketOrderArgs,
+    OrderPayload,
+    OrderType,
+    PartialCreateOrderOptions,
+    Side,
+    SignatureTypeV2,
+    TradeParams,
+)
+
+from polypocket.config import FOK_SLIPPAGE_TICKS
+from polypocket.executor import FillResult, SettlementInfo
+
+log = logging.getLogger(__name__)
+
+POLY_PROXY_SIG_TYPE = SignatureTypeV2.POLY_PROXY  # = 1
+
+CANCEL_RETRY_MAX = 2
+CANCEL_RETRY_BACKOFF_S = 0.25
+TICK_SIZE = "0.01"  # BTC up/down markets — all our markets are 1¢ tick
+```
+
+Notes:
+
+- `SignatureTypeV2.POLY_PROXY` is an `IntEnum` value of 1; passes through
+  the kwarg cleanly.
+- We hardcode `TICK_SIZE = "0.01"` rather than dynamically querying
+  `get_market(condition_id).minimum_tick_size`. Every BTC up/down market
+  we trade is 1¢. Documented in the comment.
+
+### `__init__`
+
+```python
+class PolymarketClient:
+    def __init__(
+        self,
+        host: str,
+        chain_id: int,
+        private_key: str,
+        api_creds: dict,
+        proxy_address: str,
+        dry_run: bool = False,
+    ):
+        self._dry_run = dry_run
+        creds = ApiCreds(
+            api_key=api_creds["key"],
+            api_secret=api_creds["secret"],
+            api_passphrase=api_creds["passphrase"],
+        )
+        self._client = ClobClient(
+            host=host,
+            chain_id=chain_id,
+            key=private_key,
+            creds=creds,
+            signature_type=POLY_PROXY_SIG_TYPE,
+            funder=proxy_address,
+        )
+```
+
+`_fee_rate_bps_cache` field — **deleted**. v2 handles fees server-side.
+
+### `_fee_rate_bps` method — DELETED
+
+Including the `get_market(condition_id)` lookup. No replacement.
+
+### `_tick_safe_size` — UNCHANGED
+
+Keep the workaround in place. Marked in design as a follow-up to revisit
+once we have one or two live fills with the v2 SDK and can A/B remove it.
+
+### `fok_limit_price`, `ioc_limit_price` — UNCHANGED
+
+Module-level pure functions, unrelated to SDK semantics.
+
+### `submit_fok`
+
+Old: 2 calls (`create_market_order` → `post_order(signed, OrderType.FOK)`),
+passes `fee_rate_bps`.
+
+New: single `create_and_post_market_order` call, native FOK semantics,
+no fee_rate_bps:
+
+```python
+def submit_fok(self, side, price, size, token_id, condition_id):
+    if self._dry_run:
+        log.info(
+            "DRY-RUN submit_fok side=%s price=%.4f size=%.2f token=%s cond=%s",
+            side, price, size, token_id, condition_id,
+        )
+        return FillResult(
+            status="filled", order_id="DRY-RUN",
+            filled_size=size, avg_price=price, error=None,
+        )
+
+    limit_price = fok_limit_price(price)
+    args = MarketOrderArgs(
+        token_id=token_id,
+        amount=round(size * price, 2),  # USDC budget at target price
+        side=Side.BUY,
+        price=limit_price,
+        order_type=OrderType.FOK,
+    )
+    try:
+        resp = self._client.create_and_post_market_order(
+            order_args=args,
+            options=PartialCreateOrderOptions(tick_size=TICK_SIZE),
+            order_type=OrderType.FOK,
+        )
+    except Exception as exc:
+        log.exception("submit_fok network/signing error")
+        return FillResult(
+            status="error", order_id=None, filled_size=0.0,
+            avg_price=None, error=f"network: {exc}",
+        )
+
+    # Response shape per docs: success, orderID, status (live|matched|delayed),
+    # makingAmount, takingAmount, transactionsHashes, tradeIDs, errorMsg.
+    # FOK: only treat as filled when explicit success + matched.
+    if not (resp.get("success") and resp.get("status") == "matched"):
+        err = resp.get("errorMsg") or f"status={resp.get('status')!r}"
+        return FillResult(
+            status="rejected", order_id=None, filled_size=0.0,
+            avg_price=None, error=err,
+        )
+
+    order_id = resp.get("orderID")
+    try:
+        status = self._client.get_order(order_id)
+        filled = float(status.get("size_matched", size))
+    except Exception as exc:
+        log.warning("get_order failed after successful post: %s", exc)
+        filled = size
+
+    return FillResult(
+        status="filled", order_id=order_id, filled_size=filled,
+        avg_price=price, error=None,
+    )
+```
+
+Changes from v1:
+
+- Single combined call (built-in version-update retry).
+- `side=Side.BUY` is now required on `MarketOrderArgs`.
+- `order_type` is set on the args AND passed to `create_and_post_market_order`
+  (v2 source uses the kwarg for routing).
+- `fee_rate_bps` removed.
+- Tick-size now per-call.
+
+### `submit_ioc`
+
+The v1 implementation hand-rolled true-IOC by posting GTC, checking
+`size_matched`, cancelling the remainder, and degraded-estimating fills
+when `/trades` lagged. v2's native `FAK` does this server-side.
+
+```python
+def submit_ioc(self, side, price, size, token_id, condition_id, limit_price):
+    """Post FAK at caller-supplied limit price; partial fills accepted, remainder server-cancelled."""
+    if self._dry_run:
+        log.info(
+            "DRY-RUN submit_ioc side=%s price=%.4f size=%.2f limit=%.4f token=%s cond=%s",
+            side, price, size, limit_price, token_id, condition_id,
+        )
+        return FillResult(
+            status="filled", order_id="DRY-RUN",
+            filled_size=size, avg_price=price, error=None,
+        )
+
+    # Tick-safe quantization — retained from v1 as defense-in-depth.
+    target_size_int = max(1, int(round(size)))
+    size_int = _tick_safe_size(target_size_int, limit_price)
+    if size_int is None:
+        log.error(
+            "submit_ioc: no tick-safe size near %d for limit=%.4f",
+            target_size_int, limit_price,
+        )
+        return FillResult(
+            status="rejected", order_id=None, filled_size=0.0,
+            avg_price=None, error="tick-size-unfixable",
+        )
+    amount = round(size_int * limit_price, 2)
+    args = MarketOrderArgs(
+        token_id=token_id,
+        amount=amount,
+        side=Side.BUY,
+        price=limit_price,
+        order_type=OrderType.FAK,
+    )
+
+    try:
+        resp = self._client.create_and_post_market_order(
+            order_args=args,
+            options=PartialCreateOrderOptions(tick_size=TICK_SIZE),
+            order_type=OrderType.FAK,
+        )
+    except Exception as exc:
+        log.exception("submit_ioc network/signing error")
+        return FillResult(
+            status="error", order_id=None, filled_size=0.0,
+            avg_price=None, error=f"network: {exc}",
+        )
+
+    if not resp.get("success"):
+        err = resp.get("errorMsg") or f"status={resp.get('status')!r}"
+        return FillResult(
+            status="rejected", order_id=None, filled_size=0.0,
+            avg_price=None, error=err,
+        )
+
+    order_id = resp.get("orderID")
+    if not order_id:
+        return FillResult(
+            status="rejected", order_id=None, filled_size=0.0,
+            avg_price=None, error="no-order-id",
+        )
+
+    # FAK: any partial match shows up in /trades; we read the real fill
+    # cost there (the v1 degraded-estimate path is gone because there's
+    # no GTC-then-cancel race window with native FAK).
+    try:
+        info = self.get_settlement_info(order_id)
+    except Exception as exc:
+        log.warning("submit_ioc: get_settlement_info failed for %s: %s", order_id, exc)
+        return FillResult(
+            status="rejected", order_id=order_id, filled_size=0.0,
+            avg_price=None, error=f"settlement-lookup: {exc}",
+        )
+
+    if info.shares_held <= 0:
+        return FillResult(
+            status="rejected", order_id=order_id, filled_size=0.0,
+            avg_price=None, error="fak-no-fill",
+        )
+
+    avg_price = info.cost_usdc / info.shares_held
+    return FillResult(
+        status="filled", order_id=order_id,
+        filled_size=info.shares_held, avg_price=avg_price, error=None,
+    )
+```
+
+Net deletion: ~50 lines (the `get_order` → `cancel_order` → "fully_matched"
+check → degraded-fallback estimate block in v1's `submit_ioc`).
+
+### `cancel_order`
+
+```python
+def cancel_order(self, order_id: str) -> bool:
+    """Cancel a resting order. Retries on transient errors.
+
+    Used by the startup reconciler / stranded-fill sweep. Native FAK
+    means routine fill paths no longer call cancel directly.
+    """
+    if self._dry_run:
+        return True
+
+    last_exc: Exception | None = None
+    for attempt in range(CANCEL_RETRY_MAX + 1):
+        try:
+            self._client.cancel_order(OrderPayload(orderID=order_id))
+            return True
+        except Exception as exc:
+            last_exc = exc
+            if attempt < CANCEL_RETRY_MAX:
+                time.sleep(CANCEL_RETRY_BACKOFF_S * (attempt + 1))
+    log.error("cancel_order failed after %d attempts for order %s: %s",
+              CANCEL_RETRY_MAX + 1, order_id, last_exc)
+    return False
+```
+
+If Step 1's probe shows the v2 client only exposes `cancel(order_id=str)`
+(legacy alias), swap to `self._client.cancel(order_id=order_id)`. The
+choice is one line.
+
+### `get_usdc_balance`, `get_order_status`, `get_settlement_info`
+
+Unchanged. Same signatures, same response-field reads. The internal
+HTTP call delegates to v2's pass-through `_get` for these endpoints.
+
+One log line worth adding to `get_usdc_balance` on first call after
+the migration so we capture the raw response in case the divisor needs
+adjustment:
+
+```python
+def get_usdc_balance(self) -> float:
+    params = BalanceAllowanceParams(
+        asset_type=AssetType.COLLATERAL,
+        signature_type=int(POLY_PROXY_SIG_TYPE),
+    )
+    resp = self._client.get_balance_allowance(params)
+    log.debug("get_balance_allowance raw response: %s", resp)
+    return float(resp.get("balance", 0.0)) / 1_000_000
+```
+
+(`int(POLY_PROXY_SIG_TYPE)` because `BalanceAllowanceParams.signature_type`
+is typed as `int`, not the IntEnum.)
+
+## Step 4 — Rewrite `tests/test_polymarket_client.py`
+
+Mock-surface changes. The fixture currently patches
+`polypocket.clients.polymarket.ClobClient`; same patch path works,
+but the methods we mock on the instance change. Concretely:
+
+| v1 mock | v2 mock |
+|---|---|
+| `inst.create_market_order.return_value = MagicMock()` | _delete_ |
+| `inst.post_order.return_value = {"success": True, "status": "matched", "orderID": "abc"}` | `inst.create_and_post_market_order.return_value = {"success": True, "status": "matched", "orderID": "abc"}` |
+| `inst.cancel.return_value = None` | `inst.cancel_order.return_value = None` |
+| `inst.get_market.return_value = {"taker_base_fee": 1000}` | _delete_ |
+
+Tests to update / delete:
+
+- `test_submit_fok_passes_market_fee_rate` — **delete** (no fee_rate_bps in v2).
+- `test_submit_fok_caches_market_fee` — **delete** (no fee cache in v2).
+- `test_submit_fok_market_lookup_failure_uses_zero_fee` — **delete** (no get_market call in v2).
+- All remaining `test_submit_fok_*` tests — re-point `post_order`
+  assertion to `create_and_post_market_order`.
+- All `test_submit_ioc_*` tests — re-point to
+  `create_and_post_market_order` and drop the
+  `get_order` → `cancel` → degraded-fallback assertions. Add fresh
+  tests for the FAK-native paths: full fill via `/trades`, partial fill
+  via `/trades`, server-rejected (resp.success=False), settlement
+  lookup raises, FAK matched nothing.
+- All `test_cancel_order_*` tests — re-point `inst.cancel` →
+  `inst.cancel_order`, and adjust the call-arg check to expect a
+  positional `OrderPayload(orderID=...)` not a kwarg `order_id=...`.
+
+`test_get_settlement_info_*`: unchanged — same `get_order` /
+`get_trades` shapes.
+
+The non-CLOB tests (`test_fok_limit_price_*`,
+`test_ioc_limit_price_*`) are pure-function tests; **no changes**.
+
+Run after edits:
+
+```powershell
+pytest tests/test_polymarket_client.py -v
+```
+
+Then the full suite:
+
+```powershell
+pytest tests/ -v
+```
+
+## Step 5 — Migrate scripts
+
+`scripts/diagnose_live_auth.py`:
+
+- Imports: `from py_clob_client.client import ClobClient` →
+  `from py_clob_client_v2 import ClobClient`; same for
+  `clob_types`-imported names.
+- The `[(0, "EOA"), (1, "POLY_PROXY"), (2, "POLY_GNOSIS_SAFE")]` loop
+  body uses signature_type integers; keep the literals but reference
+  `SignatureTypeV2` for clarity in the labels.
+
+`scripts/derive_clob_creds.py`:
+
+- Same import swap. If it calls `client.create_or_derive_api_key()`, the
+  v2 surface is identical (verified in v2 source `client.py:508`).
+
+`scripts/check_stranded_fills.py`:
+
+- Reads via our `PolymarketClient` wrapper. Likely zero changes after
+  the wrapper rewrite. Confirm by `grep -n "py_clob_client" scripts/check_stranded_fills.py`
+  and adjust only if direct SDK imports exist.
+
+Probe scripts (`probe_gtc_cancel.py`, `probe_pair_merge_limit.py`):
+defer. Not on the live path; archive-only.
+
+## Step 6 — Paper-mode smoke
+
+```powershell
+$env:TRADING_MODE = "paper"
+python -m polypocket
+```
+
+(Or whatever the standard bot start command is — there's an alias in
+the project; the `__main__.py` exposes the same entry point.)
+
+Watch for:
+
+1. Import-time success (no `ModuleNotFoundError` on `py_clob_client_v2`).
+2. One full decision/close cycle: a fresh row in
+   `window_snapshots` with `snapshot_type='decision'` and the matching
+   `close` row 5 min later.
+3. No new `ERROR` lines in stderr.
+
+Cancel the bot after 1–2 windows.
+
+Paper mode doesn't construct `PolymarketClient` (TRADING_MODE=paper
+short-circuits at `__main__.py:50`), so this is purely import-time
+correctness — but that alone has caught regressions before.
+
+## Step 7 — Single-shot live probe
+
+Write a throwaway script (don't commit) that does one minimum-size FOK
+against a real BTC up/down market on the production CLOB:
+
+```python
+# scripts/_probe_v2_fok.py  (gitignored)
+import os
+from polypocket.clients.polymarket import PolymarketClient, fok_limit_price
+from polypocket import config
+
+client = PolymarketClient(
+    host=config.POLYMARKET_HOST,
+    chain_id=config.CHAIN_ID,
+    private_key=os.environ["PRIVATE_KEY"],
+    api_creds={
+        "key": os.environ["CLOB_API_KEY"],
+        "secret": os.environ["CLOB_SECRET"],
+        "passphrase": os.environ["CLOB_PASSPHRASE"],
+    },
+    proxy_address=os.environ["PROXY_ADDRESS"],
+    dry_run=False,
+)
+
+print("balance:", client.get_usdc_balance())  # should be >0 in pUSD
+
+# Pick an active BTC up/down market token_id + condition_id manually
+# (grab from /markets or the web UI). Choose a market deep enough
+# that a 5-share order at the best ask is trivially fillable.
+TOKEN_ID = "..."       # fill in
+CONDITION_ID = "..."   # fill in
+SIZE = 5               # ~$2–$4 depending on price
+PRICE = 0.50           # placeholder; replace with current best ask + small cushion
+
+fill = client.submit_fok(
+    side="up", price=PRICE, size=SIZE,
+    token_id=TOKEN_ID, condition_id=CONDITION_ID,
+)
+print(fill)
+
+if fill.status == "filled":
+    info = client.get_settlement_info(fill.order_id)
+    print("settlement:", info)
+```
+
+Acceptance for this probe:
+
+- `client.get_usdc_balance()` returns a sensible $>0 number — confirms
+  pUSD balance is visible to v2 SDK at the right decimal scale.
+- `fill.status == "filled"` (or `"rejected"` with `"fak-no-fill"` if
+  the book moved — either way, the *server-level* rejection
+  `order_version_mismatch` MUST NOT appear).
+- `get_settlement_info` returns `shares_held > 0` and
+  `cost_usdc` within a cent of `SIZE * fill.avg_price`.
+
+If `fill.error` contains `insufficient allowance` or
+`balance/allowance error`, the manual pUSD allowance step was
+incomplete — pause and fix on-chain before proceeding.
+
+If anything else fails: STOP. Do not flip the bot to live with a
+partial migration.
+
+## Step 8 — Flip to live
+
+```powershell
+$env:TRADING_MODE = "live"
+python -m polypocket
+```
+
+Watch the first 3–5 decision windows by tailing the log and querying
+`window_snapshots` + `trades` between windows:
+
+```powershell
+# After ~15 min of live mode:
+sqlite3 live_trades.db "SELECT id, timestamp, side, status, error FROM trades WHERE timestamp > datetime('now', '-1 hour') ORDER BY id"
+```
+
+Acceptance: any `trade_fired=1` decision results in a row with
+`status='open'` (filled) or `status='rejected'` with an error that is
+NOT `order_version_mismatch` or `insufficient allowance`.
+
+If 2 consecutive trade attempts in live mode fail with the same error
+class, stop the bot and investigate before letting it keep churning.
+
+## Step 9 — Commit + PR
+
+Conventional-style commits:
+
+```
+chore: pin py-clob-client-v2 in pyproject.toml
+feat(clients): migrate Polymarket client to py-clob-client-v2 SDK
+test(clients): retarget mocks at py-clob-client-v2 surface
+chore(scripts): swap py_clob_client imports for v2 in diagnostic scripts
+docs(plans): clob v2 migration design + implementation
+```
+
+PR title: `feat: migrate to py-clob-client-v2 after CLOB v2 cutover`.
+Reference the existing live-rejection observation in the description.
+
+## Step 10 — Update memory after stable live runs
+
+Once Step 8 produces at least one settled live trade with a real PnL:
+
+- Update `polymarket_clob_v2_migration.md` from "migration blocker"
+  framing to a historical fact (migration completed at <commit-sha>).
+- Update `polymarket_account_type.md` to note the funder's allowances
+  are now against the V2 Exchange contracts (the v1 addresses in the
+  current note are stale).
+- Consider writing a new reference memory `polymarket_v2_contracts.md`
+  with the V2 exchange addresses + pUSD token address, since these
+  are stable facts likely to be referenced again.
+
+## Effort estimate
+
+| Step | Time |
+|---|---|
+| 1 — branch + dep swap | 5 min |
+| 2 — DB backup | 1 min |
+| 3 — rewrite polymarket.py | 60–90 min |
+| 4 — rewrite tests | 60–90 min |
+| 5 — migrate scripts | 15 min |
+| 6 — paper smoke | 10 min |
+| 7 — live probe | 20 min |
+| 8 — live flip + watch | 30 min |
+| 9 — commit + PR | 15 min |
+
+Total: ~3.5–4.5 hours of focused work. Most of it is the test-mock
+retrofit in Step 4.

--- a/polypocket/clients/polymarket.py
+++ b/polypocket/clients/polymarket.py
@@ -1,16 +1,20 @@
-"""Polymarket CLOB client — L2 proxy-wallet signing."""
+"""Polymarket CLOB v2 client — L2 proxy-wallet signing."""
 
 import logging
 import math
 import time
 
-from py_clob_client.client import ClobClient
-from py_clob_client.clob_types import (
+from py_clob_client_v2 import (
     ApiCreds,
     AssetType,
     BalanceAllowanceParams,
+    ClobClient,
     MarketOrderArgs,
+    OrderPayload,
     OrderType,
+    PartialCreateOrderOptions,
+    Side,
+    SignatureTypeV2,
     TradeParams,
 )
 
@@ -19,13 +23,19 @@ from polypocket.executor import FillResult, SettlementInfo
 
 log = logging.getLogger(__name__)
 
-# POLY_PROXY=1 is the proxy-wallet signing path used by Polymarket's
+# Signature type 1 is the proxy-wallet signing path used by Polymarket's
 # email/OAuth signup flow (the wallet on file is a POLY_PROXY contract that
-# owns the USDC — balances/allowances are keyed on the proxy, orders are
+# owns the pUSD — balances/allowances are keyed on the proxy, orders are
 # signed by the EOA but executed as the proxy). Verified empirically against
 # this account: sig_type=2 (POLY_GNOSIS_SAFE) returns $0; sig_type=1 returns
-# the real balance.
-POLY_PROXY_SIG_TYPE = 1
+# the real balance. v2 preserves this signature scheme; the only on-server
+# change was the EIP-712 Exchange domain version bumping "1" → "2".
+POLY_PROXY_SIG_TYPE = SignatureTypeV2.POLY_PROXY  # IntEnum value = 1
+
+# All BTC up/down markets use 1¢ ticks. Hardcoded rather than queried per
+# order to avoid a roundtrip; if a future market type ever needs a different
+# tick size, plumb it through from the bot.
+TICK_SIZE = "0.01"
 
 CANCEL_RETRY_MAX = 2
 CANCEL_RETRY_BACKOFF_S = 0.25
@@ -38,11 +48,15 @@ def fok_limit_price(price: float) -> float:
 
 def _tick_safe_size(target_size: int, limit_price: float, search: int = 6) -> int | None:
     """Pick an integer size where amount = round(size*limit, 2) survives
-    py_clob_client's float-based round_down. Some (size, limit) combos produce
-    amount values like 4.56 whose float rep is 4.5599999...; py_clob_client's
-    round_down then floors into the previous cent, corrupting the reconstructed
-    taker and tripping the server's 0.01 tick check. Searches ±search around
-    target and returns the first safe size, or None.
+    float-based round_down at the order builder. Some (size, limit) combos
+    produce amount values like 4.56 whose float rep is 4.5599999...; if the
+    builder floors that into the previous cent, the reconstructed taker
+    trips the server's 0.01 tick check. Searches ±search around target and
+    returns the first safe size, or None.
+
+    Retained from the v1 SDK era as defense-in-depth. v2's order builder
+    is rewritten and likely doesn't need this; revisit removal once we
+    have a few clean v2 fills to A/B against.
 
     Critical: the check must go through `round(..., 2)` first, since
     `(s * limit) * 100` and `round(s * limit, 2) * 100` often have different
@@ -87,7 +101,7 @@ def ioc_limit_price(
 
 
 class PolymarketClient:
-    """Concrete LiveOrderClient for Polymarket's CLOB using L2 proxy signing."""
+    """Concrete LiveOrderClient for Polymarket's CLOB v2 using L2 proxy signing."""
 
     def __init__(
         self,
@@ -106,31 +120,12 @@ class PolymarketClient:
         )
         self._client = ClobClient(
             host=host,
-            key=private_key,
             chain_id=chain_id,
+            key=private_key,
             creds=creds,
             signature_type=POLY_PROXY_SIG_TYPE,
             funder=proxy_address,
         )
-        # Per-market taker fee cache. Polymarket rejects orders with
-        # `feeRateBps=0` when the market's `taker_base_fee` is non-zero
-        # (BTC up/down markets report 1000). We look it up once per
-        # condition_id and reuse.
-        self._fee_rate_bps_cache: dict[str, int] = {}
-
-    def _fee_rate_bps(self, condition_id: str) -> int:
-        cached = self._fee_rate_bps_cache.get(condition_id)
-        if cached is not None:
-            return cached
-        try:
-            market = self._client.get_market(condition_id)
-            fee = int(market.get("taker_base_fee", 0) or 0)
-        except Exception as exc:
-            log.warning("get_market(%s) failed, defaulting fee_rate_bps=0: %s",
-                        condition_id, exc)
-            fee = 0
-        self._fee_rate_bps_cache[condition_id] = fee
-        return fee
 
     def submit_fok(self, side, price, size, token_id, condition_id):
         if self._dry_run:
@@ -143,24 +138,20 @@ class PolymarketClient:
                 filled_size=size, avg_price=price, error=None,
             )
 
-        fee_rate_bps = self._fee_rate_bps(condition_id)
-        # FOK must go through create_market_order: Polymarket requires
-        # makerAmount accuracy of 2 decimals and takerAmount 4 decimals
-        # for taker-style orders. The limit-order path (create_order +
-        # OrderArgs.size) produces 4-decimal makerAmount (e.g. 27.78 *
-        # 0.36 = 10.0008) and is rejected with `invalid amounts`.
-        # Market-order path computes makerAmount = round_down(amount, 2)
-        # directly, which the server accepts.
         limit_price = fok_limit_price(price)
         args = MarketOrderArgs(
             token_id=token_id,
             amount=round(size * price, 2),  # USDC budget at target price
-            price=limit_price,              # allow sweeping up to +N ticks
-            fee_rate_bps=fee_rate_bps,
+            side=Side.BUY,
+            price=limit_price,
+            order_type=OrderType.FOK,
         )
         try:
-            signed = self._client.create_market_order(args)
-            resp = self._client.post_order(signed, OrderType.FOK)
+            resp = self._client.create_and_post_market_order(
+                order_args=args,
+                options=PartialCreateOrderOptions(tick_size=TICK_SIZE),
+                order_type=OrderType.FOK,
+            )
         except Exception as exc:
             log.exception("submit_fok network/signing error")
             return FillResult(
@@ -168,9 +159,11 @@ class PolymarketClient:
                 avg_price=None, error=f"network: {exc}",
             )
 
-        # FOK semantics: only treat as filled when the server explicitly reports
-        # success AND status=="matched". Anything else (success with status
-        # "unmatched"/"delayed", missing status, success=False) is a reject.
+        # v2 response shape (verified against
+        # https://docs.polymarket.com/api-reference/trade/post-a-new-order.md):
+        # success, orderID, status (live|matched|delayed), makingAmount,
+        # takingAmount, transactionsHashes, tradeIDs, errorMsg.
+        # FOK: only treat as filled when explicit success + matched.
         if not (resp.get("success") and resp.get("status") == "matched"):
             err = resp.get("errorMsg") or f"status={resp.get('status')!r}"
             return FillResult(
@@ -192,11 +185,11 @@ class PolymarketClient:
         )
 
     def submit_ioc(self, side, price, size, token_id, condition_id, limit_price):
-        """Post GTC at caller-supplied limit price, immediately cancel remainder.
+        """Post FAK at caller-supplied limit price; partial fills accepted,
+        remainder server-cancelled.
 
-        True-IOC semantic layered on GTC since py_clob_client doesn't expose
-        IOC natively. Any match at <= limit_price fills; remainder is
-        cancelled. limit_price is computed upstream (pair-merge-aware via
+        v2's native FAK ("Fill And Kill") replaces the v1-era GTC+manual-cancel
+        workaround. limit_price is computed upstream (pair-merge-aware via
         `ioc_limit_price`) since only the bot sees both books. Returned
         filled_size is shares_held from per-fill /trades data (post-fee).
         """
@@ -210,11 +203,7 @@ class PolymarketClient:
                 filled_size=size, avg_price=price, error=None,
             )
 
-        fee_rate_bps = self._fee_rate_bps(condition_id)
-        # Tick-safe amount: quantize size to integer and pick a neighbor whose
-        # amount = size * limit_price survives py_clob_client's float-based
-        # round_down. Otherwise the server tick-checks the reconstructed
-        # taker and rejects with `breaks minimum tick size rule: 0.01`.
+        # Tick-safe quantization — retained from v1 as defense-in-depth.
         target_size_int = max(1, int(round(size)))
         size_int = _tick_safe_size(target_size_int, limit_price)
         if size_int is None:
@@ -230,13 +219,17 @@ class PolymarketClient:
         args = MarketOrderArgs(
             token_id=token_id,
             amount=amount,
+            side=Side.BUY,
             price=limit_price,
-            fee_rate_bps=fee_rate_bps,
+            order_type=OrderType.FAK,
         )
 
         try:
-            signed = self._client.create_market_order(args)
-            resp = self._client.post_order(signed, OrderType.GTC)
+            resp = self._client.create_and_post_market_order(
+                order_args=args,
+                options=PartialCreateOrderOptions(tick_size=TICK_SIZE),
+                order_type=OrderType.FAK,
+            )
         except Exception as exc:
             log.exception("submit_ioc network/signing error")
             return FillResult(
@@ -258,60 +251,25 @@ class PolymarketClient:
                 avg_price=None, error="no-order-id",
             )
 
-        # Check how much matched before deciding whether to cancel remainder.
-        # Skip cancel if order fully matched (server errors on cancel-of-filled).
-        size_matched = 0.0
-        try:
-            order_status = self._client.get_order(order_id)
-            if order_status:
-                size_matched = float(order_status.get("size_matched", 0) or 0)
-        except Exception as exc:
-            log.warning("submit_ioc: get_order check failed for %s: %s", order_id, exc)
-
-        # Compare against the integer size we actually submitted, not the
-        # caller's pre-quantization float size.
-        fully_matched = size_matched >= size_int - 0.01
-        if not fully_matched:
-            self.cancel_order(order_id)
-
-        # Fast path: nothing matched, so skip the /trades settlement lookup
-        # entirely. Avoids hitting the /order null-body race when the server
-        # hasn't indexed the cancel yet — which previously propagated as a
-        # spurious `settlement-lookup: NoneType` error and lost the
-        # external_order_id linkage for the reconciler.
-        if size_matched <= 0:
-            return FillResult(
-                status="rejected", order_id=order_id, filled_size=0.0,
-                avg_price=None, error="gtc-no-fill",
-            )
-
-        # Derive real fill from per-fill /trades data (post-fee shares).
+        # FAK: read the real fill cost from /trades. v2 handles the
+        # cancel-remainder server-side, so there's no GTC-then-cancel
+        # indexing race window for us to estimate around.
         try:
             info = self.get_settlement_info(order_id)
         except Exception as exc:
             log.warning("submit_ioc: get_settlement_info failed for %s: %s", order_id, exc)
-            info = SettlementInfo(shares_held=0.0, cost_usdc=0.0)
-
-        # Degraded path: first get_order saw a real match but /trades is
-        # empty (null body, indexing lag, or partial /trades propagation).
-        # Fall back to a pessimistic estimate from the known size_matched +
-        # market fee — better than marking a real fill as rejected, which
-        # would strand the position.
-        if info.shares_held <= 0:
-            fee_bps = self._fee_rate_bps(condition_id)
-            est_shares = size_matched * (1.0 - fee_bps / 10_000.0)
-            log.error(
-                "submit_ioc: settlement data unavailable for %s with "
-                "size_matched=%.4f; using pessimistic estimate "
-                "shares=%.4f cost≈$%.4f (fill may have landed better)",
-                order_id, size_matched, est_shares, size_matched * limit_price,
-            )
             return FillResult(
-                status="filled", order_id=order_id,
-                filled_size=est_shares, avg_price=limit_price, error=None,
+                status="rejected", order_id=order_id, filled_size=0.0,
+                avg_price=None, error=f"settlement-lookup: {exc}",
             )
 
-        avg_price = info.cost_usdc / info.shares_held if info.shares_held > 0 else price
+        if info.shares_held <= 0:
+            return FillResult(
+                status="rejected", order_id=order_id, filled_size=0.0,
+                avg_price=None, error="fak-no-fill",
+            )
+
+        avg_price = info.cost_usdc / info.shares_held
         return FillResult(
             status="filled", order_id=order_id,
             filled_size=info.shares_held, avg_price=avg_price, error=None,
@@ -320,9 +278,11 @@ class PolymarketClient:
     def cancel_order(self, order_id: str) -> bool:
         """Cancel a resting order. Retries on transient errors.
 
-        Returns True on success, False if all retries fail. Errors are logged
-        but not raised — the caller records whatever matched via /trades and
-        the startup reconciler catches orphans.
+        Used by the startup reconciler / stranded-fill sweep. Native FAK
+        means routine fill paths no longer call cancel directly — partial
+        fills are server-side cancelled inside `create_and_post_market_order`.
+
+        Returns True on success, False if all retries fail.
         """
         if self._dry_run:
             return True
@@ -330,7 +290,7 @@ class PolymarketClient:
         last_exc: Exception | None = None
         for attempt in range(CANCEL_RETRY_MAX + 1):
             try:
-                self._client.cancel(order_id=order_id)
+                self._client.cancel_order(OrderPayload(orderID=order_id))
                 return True
             except Exception as exc:
                 last_exc = exc
@@ -341,15 +301,20 @@ class PolymarketClient:
         return False
 
     def get_usdc_balance(self) -> float:
+        """Fetch the collateral (pUSD) balance for the proxy wallet.
+
+        Polymarket returns the balance as a string of raw on-chain units.
+        pUSD is a USDC-backed ERC-20 with 6 decimals on Polygon, so the
+        /1_000_000 divisor from the USDC.e era still applies. Debug log
+        captures the raw response so the divisor can be re-confirmed if
+        anything ever drifts.
+        """
         params = BalanceAllowanceParams(
             asset_type=AssetType.COLLATERAL,
-            signature_type=POLY_PROXY_SIG_TYPE,
+            signature_type=int(POLY_PROXY_SIG_TYPE),
         )
         resp = self._client.get_balance_allowance(params)
-        # Polymarket returns USDC balance as a string of raw on-chain units
-        # (6 decimals, matching `to_token_decimals` in py_clob_client). Convert
-        # to dollars so caller-side `< MIN_POSITION_USDC` and `< size * price`
-        # gates compare in the right units.
+        log.debug("get_balance_allowance raw response: %s", resp)
         return float(resp.get("balance", 0.0)) / 1_000_000
 
     def get_order_status(self, order_id: str) -> dict:
@@ -376,10 +341,9 @@ class PolymarketClient:
             return SettlementInfo(shares_held=0.0, cost_usdc=0.0)
 
         order = self._client.get_order(order_id)
-        # Polymarket's /order endpoint occasionally returns a null body for an
-        # order ID that's still propagating (observed within ~500 ms of a post
-        # or between post+cancel). Treat as "no data yet" instead of crashing
-        # — the caller decides whether to trust the prior size_matched or not.
+        # /order occasionally returns a null body for an order ID that's still
+        # propagating (observed within ~500 ms of a post on v1; behavior on v2
+        # may differ but defensive treatment costs nothing).
         if not order:
             return SettlementInfo(shares_held=0.0, cost_usdc=0.0)
         trade_ids = order.get("associate_trades") or []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Directional 5-minute BTC prediction bot for Polymarket"
 requires-python = ">=3.11"
 dependencies = [
     "ccxt>=4.0.0",
-    "py-clob-client==0.19.0",
+    "py-clob-client-v2==1.0.1",
     "websockets>=12.0",
     "textual>=3.0.0",
     "scipy>=1.11.0",

--- a/scripts/check_stranded_fills.py
+++ b/scripts/check_stranded_fills.py
@@ -10,8 +10,7 @@ be swept — this script is the one-time backfill.
 import logging
 import sqlite3
 
-from py_clob_client.client import ClobClient
-from py_clob_client.clob_types import ApiCreds, TradeParams
+from py_clob_client_v2 import ApiCreds, ClobClient, TradeParams
 
 from polypocket.clients.polymarket import PolymarketClient, POLY_PROXY_SIG_TYPE
 from polypocket.config import (

--- a/scripts/derive_clob_creds.py
+++ b/scripts/derive_clob_creds.py
@@ -13,7 +13,7 @@ import os
 import sys
 
 from dotenv import load_dotenv
-from py_clob_client.client import ClobClient
+from py_clob_client_v2 import ClobClient
 
 
 def main() -> None:
@@ -27,7 +27,7 @@ def main() -> None:
     chain_id = int(os.getenv("CHAIN_ID", "137"))
 
     client = ClobClient(host=host, key=private_key, chain_id=chain_id)
-    creds = client.create_or_derive_api_creds()
+    creds = client.create_or_derive_api_key()
 
     print()
     print("# Paste these into your .env:")

--- a/scripts/diagnose_live_auth.py
+++ b/scripts/diagnose_live_auth.py
@@ -33,11 +33,11 @@ import os
 import sys
 
 from dotenv import load_dotenv
-from py_clob_client.client import ClobClient
-from py_clob_client.clob_types import (
-    ApiCreds, AssetType, BalanceAllowanceParams, OrderArgs, OrderType,
+from py_clob_client_v2 import (
+    ApiCreds, AssetType, BalanceAllowanceParams, ClobClient,
+    MarketOrderArgs, OrderType, PartialCreateOrderOptions, Side,
+    SignatureTypeV2,
 )
-from py_clob_client.order_builder.constants import BUY
 
 
 def main() -> None:
@@ -77,7 +77,13 @@ def main() -> None:
     print("=" * 70)
     print("Step 2 — /balance-allowance per sig_type (server-side funder lookup)")
     print("=" * 70)
-    for sig_type, label in [(0, "EOA"), (1, "POLY_PROXY"), (2, "POLY_GNOSIS_SAFE")]:
+    for sig_type_enum, label in [
+        (SignatureTypeV2.EOA, "EOA"),
+        (SignatureTypeV2.POLY_PROXY, "POLY_PROXY"),
+        (SignatureTypeV2.POLY_GNOSIS_SAFE, "POLY_GNOSIS_SAFE"),
+        (SignatureTypeV2.POLY_1271, "POLY_1271"),
+    ]:
+        sig_type = int(sig_type_enum)
         try:
             client = ClobClient(host=host, key=pk, chain_id=chain_id, creds=creds,
                                 signature_type=sig_type, funder=proxy)
@@ -107,23 +113,33 @@ def main() -> None:
 
     # === Step 3: tiny order probe ==========================================
     print("=" * 70)
-    print("Step 3 — Order-submit probe (sig_type=1 first, then 0 and 2)")
+    print("Step 3 — Order-submit probe (sig_type=1 first, then 0, 2, 3)")
     print("=" * 70)
-    for sig_type, label in [(1, "POLY_PROXY"), (0, "EOA"), (2, "POLY_GNOSIS_SAFE")]:
+    for sig_type_enum, label in [
+        (SignatureTypeV2.POLY_PROXY, "POLY_PROXY"),
+        (SignatureTypeV2.EOA, "EOA"),
+        (SignatureTypeV2.POLY_GNOSIS_SAFE, "POLY_GNOSIS_SAFE"),
+        (SignatureTypeV2.POLY_1271, "POLY_1271"),
+    ]:
+        sig_type = int(sig_type_enum)
         client = ClobClient(host=host, key=pk, chain_id=chain_id, creds=creds,
                             signature_type=sig_type, funder=proxy)
+        # Place a FOK at $0.01 (way below any UP/DOWN ask) — will reject
+        # unfilled but the REJECT reason tells us what the server thinks.
+        # v2: no fee_rate_bps (server-computed); Side.BUY required on args.
+        args = MarketOrderArgs(
+            token_id=token_id,
+            amount=0.05,  # $0.05 budget
+            side=Side.BUY,
+            price=0.01,
+            order_type=OrderType.FOK,
+        )
         try:
-            market = client.get_market(condition_id)
-            fee = int(market.get("taker_base_fee", 0) or 0)
-        except Exception:
-            fee = 0
-        # Place at $0.01 (way below any UP/DOWN ask) — will reject unfilled
-        # but the REJECT reason tells us what the server thinks.
-        args = OrderArgs(token_id=token_id, price=0.01, size=5.0,
-                         side=BUY, fee_rate_bps=fee)
-        try:
-            signed = client.create_order(args)
-            resp = client.post_order(signed, OrderType.FOK)
+            resp = client.create_and_post_market_order(
+                order_args=args,
+                options=PartialCreateOrderOptions(tick_size="0.01"),
+                order_type=OrderType.FOK,
+            )
             print(f"  sig_type={sig_type} ({label:16}) server resp: {resp}")
         except Exception as exc:
             print(f"  sig_type={sig_type} ({label:16}) RAISED: {type(exc).__name__}: {exc}")

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -15,11 +15,10 @@ def mock_clob():
 
 def _make_client(mock_clob_cls, dry_run=False):
     instance = mock_clob_cls.return_value
-    # Polymarket returns USDC balance in raw 6-decimal on-chain units.
+    # Polymarket returns collateral balance in raw 6-decimal on-chain units.
+    # pUSD (the v2-era collateral) is a USDC-backed ERC-20 with the same scale.
     # 1_234_500_000 raw = $1234.50.
     instance.get_balance_allowance.return_value = {"balance": "1234500000"}
-    # Default: BTC up/down markets report taker_base_fee=1000.
-    instance.get_market.return_value = {"taker_base_fee": 1000}
     return PolymarketClient(
         host="https://clob.polymarket.com", chain_id=137,
         private_key="0x" + "1" * 64,
@@ -31,8 +30,9 @@ def _make_client(mock_clob_cls, dry_run=False):
 
 def test_submit_fok_filled(mock_clob):
     client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {"success": True, "status": "matched", "orderID": "abc"}
+    inst.create_and_post_market_order.return_value = {
+        "success": True, "status": "matched", "orderID": "abc",
+    }
     inst.get_order.return_value = {"status": "matched", "size_matched": "7.0"}
 
     fill = client.submit_fok(side="up", price=0.51, size=7.0,
@@ -41,79 +41,62 @@ def test_submit_fok_filled(mock_clob):
     assert fill.status == "filled"
     assert fill.order_id == "abc"
     assert fill.filled_size == pytest.approx(7.0)
-    inst.post_order.assert_called_once()
+    inst.create_and_post_market_order.assert_called_once()
 
 
-def test_submit_fok_passes_market_fee_rate(mock_clob):
-    """MarketOrderArgs.fee_rate_bps must come from the market's taker_base_fee."""
+def test_submit_fok_passes_v2_market_order_args(mock_clob):
+    """v2 MarketOrderArgs: side=Side.BUY, order_type=FOK, no fee_rate_bps."""
+    from py_clob_client_v2 import OrderType, Side
     client, inst = _make_client(mock_clob)
-    inst.get_market.return_value = {"taker_base_fee": 1000}
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {"success": True, "status": "matched", "orderID": "abc"}
+    inst.create_and_post_market_order.return_value = {
+        "success": True, "status": "matched", "orderID": "abc",
+    }
     inst.get_order.return_value = {"status": "matched", "size_matched": "7.0"}
 
     client.submit_fok(side="up", price=0.51, size=7.0,
                       token_id="TKN-UP", condition_id="0xCOND")
 
-    inst.create_market_order.assert_called_once()
-    args = inst.create_market_order.call_args.args[0]
-    assert args.fee_rate_bps == 1000
+    kwargs = inst.create_and_post_market_order.call_args.kwargs
+    args = kwargs["order_args"]
     assert args.token_id == "TKN-UP"
+    assert args.side == Side.BUY
+    assert args.order_type == OrderType.FOK
     # amount = USDC budget at the target price (2-dp precision rule)
     assert args.amount == pytest.approx(round(7.0 * 0.51, 2))
     # price = limit (max) price, with FOK_SLIPPAGE_TICKS buffer so taker
     # can sweep thin levels instead of killing at the quoted ask
     from polypocket.config import FOK_SLIPPAGE_TICKS
     assert args.price == pytest.approx(round(0.51 + FOK_SLIPPAGE_TICKS * 0.01, 2))
+    # tick size passed via PartialCreateOrderOptions
+    options = kwargs["options"]
+    assert options.tick_size == "0.01"
+    # order_type also passed as top-level kwarg
+    assert kwargs["order_type"] == OrderType.FOK
+    # v2 removes fee_rate_bps from MarketOrderArgs — no such attribute or zero default
+    assert getattr(args, "fee_rate_bps", 0) == 0
 
 
 def test_submit_fok_limit_price_capped_at_99c(mock_clob):
     """Limit price must never exceed $0.99 — Polymarket rejects price==1.0."""
     client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {"success": True, "status": "matched", "orderID": "x"}
+    inst.create_and_post_market_order.return_value = {
+        "success": True, "status": "matched", "orderID": "x",
+    }
     inst.get_order.return_value = {"status": "matched", "size_matched": "1.0"}
 
     client.submit_fok(side="up", price=0.98, size=1.0,
                       token_id="TKN-UP", condition_id="0xCOND")
 
-    args = inst.create_market_order.call_args.args[0]
+    args = inst.create_and_post_market_order.call_args.kwargs["order_args"]
     assert args.price <= 0.99
-
-
-def test_submit_fok_caches_market_fee(mock_clob):
-    """get_market must be called only once per condition_id across submissions."""
-    client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {"success": True, "status": "matched", "orderID": "x"}
-    inst.get_order.return_value = {"status": "matched", "size_matched": "1.0"}
-
-    for _ in range(3):
-        client.submit_fok(side="up", price=0.51, size=1.0,
-                          token_id="TKN-UP", condition_id="0xCOND")
-
-    assert inst.get_market.call_count == 1
-
-
-def test_submit_fok_market_lookup_failure_uses_zero_fee(mock_clob):
-    client, inst = _make_client(mock_clob)
-    inst.get_market.side_effect = RuntimeError("market lookup down")
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {"success": True, "status": "matched", "orderID": "x"}
-    inst.get_order.return_value = {"status": "matched", "size_matched": "1.0"}
-
-    client.submit_fok(side="up", price=0.51, size=1.0,
-                      token_id="TKN-UP", condition_id="0xCOND")
-
-    args = inst.create_market_order.call_args.args[0]
-    assert args.fee_rate_bps == 0
 
 
 def test_submit_fok_success_but_unmatched_is_rejected(mock_clob):
     """FOK: `success=True, status='unmatched'` must NOT be recorded as filled."""
     client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {"success": True, "status": "unmatched"}
+    inst.create_and_post_market_order.return_value = {
+        "success": True, "status": "unmatched",
+    }
 
     fill = client.submit_fok(side="up", price=0.51, size=7.0,
                              token_id="TKN-UP", condition_id="0xCOND")
@@ -126,8 +109,9 @@ def test_submit_fok_success_but_unmatched_is_rejected(mock_clob):
 
 def test_submit_fok_rejected(mock_clob):
     client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {"success": False, "errorMsg": "not matched"}
+    inst.create_and_post_market_order.return_value = {
+        "success": False, "errorMsg": "not matched",
+    }
 
     fill = client.submit_fok(side="up", price=0.51, size=7.0,
                              token_id="TKN-UP", condition_id="0xCOND")
@@ -140,7 +124,7 @@ def test_submit_fok_rejected(mock_clob):
 
 def test_submit_fok_network_error(mock_clob):
     client, inst = _make_client(mock_clob)
-    inst.create_market_order.side_effect = RuntimeError("boom")
+    inst.create_and_post_market_order.side_effect = RuntimeError("boom")
 
     fill = client.submit_fok(side="up", price=0.51, size=7.0,
                              token_id="TKN-UP", condition_id="0xCOND")
@@ -157,13 +141,15 @@ def test_submit_fok_dry_run_does_not_post(mock_clob):
 
     assert fill.status == "filled"
     assert fill.order_id == "DRY-RUN"
-    inst.create_market_order.assert_not_called()
-    inst.post_order.assert_not_called()
-    inst.get_market.assert_not_called()
+    inst.create_and_post_market_order.assert_not_called()
 
 
 def test_get_usdc_balance_converts_raw_units_to_dollars(mock_clob):
-    """Polymarket /balance-allowance returns 6-decimal raw units; client must divide."""
+    """Polymarket /balance-allowance returns 6-decimal raw units; client must divide.
+
+    pUSD inherits the same 6-decimal scale as USDC.e, so the conversion is
+    unchanged from the v1 era.
+    """
     client, inst = _make_client(mock_clob)
     inst.get_balance_allowance.return_value = {"balance": "42700000"}  # $42.70 raw
 
@@ -361,12 +347,29 @@ def test_get_settlement_info_dry_run_returns_zeros(mock_clob):
     inst.get_order.assert_not_called()
 
 
-def test_cancel_order_success(mock_clob):
+def test_get_settlement_info_handles_null_order_body(mock_clob):
+    """Defensive None-guard: /order may return null body during indexing lag."""
     client, inst = _make_client(mock_clob)
-    inst.cancel.return_value = {"canceled": ["abc"]}
+    inst.get_order.return_value = None
+
+    info = client.get_settlement_info("0xOID")
+
+    assert info.shares_held == 0.0
+    assert info.cost_usdc == 0.0
+    inst.get_trades.assert_not_called()
+
+
+def test_cancel_order_success(mock_clob):
+    from py_clob_client_v2 import OrderPayload
+    client, inst = _make_client(mock_clob)
+    inst.cancel_order.return_value = {"canceled": ["abc"]}
     ok = client.cancel_order("abc")
     assert ok is True
-    inst.cancel.assert_called_once_with(order_id="abc")
+    inst.cancel_order.assert_called_once()
+    # v2 cancel_order takes OrderPayload(orderID=...) positionally
+    payload = inst.cancel_order.call_args.args[0]
+    assert isinstance(payload, OrderPayload)
+    assert payload.orderID == "abc"
 
 
 def test_cancel_order_dry_run(mock_clob):
@@ -377,29 +380,27 @@ def test_cancel_order_dry_run(mock_clob):
 
 def test_cancel_order_retries_then_succeeds(mock_clob):
     client, inst = _make_client(mock_clob)
-    inst.cancel.side_effect = [Exception("transient"), {"canceled": ["abc"]}]
+    inst.cancel_order.side_effect = [Exception("transient"), {"canceled": ["abc"]}]
     ok = client.cancel_order("abc")
     assert ok is True
-    assert inst.cancel.call_count == 2
+    assert inst.cancel_order.call_count == 2
 
 
 def test_cancel_order_gives_up_after_retries(mock_clob):
     client, inst = _make_client(mock_clob)
-    inst.cancel.side_effect = Exception("persistent")
+    inst.cancel_order.side_effect = Exception("persistent")
     ok = client.cancel_order("abc")
     assert ok is False
-    assert inst.cancel.call_count == 3  # 1 + 2 retries (CANCEL_RETRY_MAX=2)
+    assert inst.cancel_order.call_count == 3  # 1 + 2 retries (CANCEL_RETRY_MAX=2)
 
 
 def test_submit_ioc_full_match(mock_clob):
+    """FAK fully fills: server-side cancel-remainder is a no-op; /trades has the fill."""
     client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {
+    inst.create_and_post_market_order.return_value = {
         "success": True, "status": "matched", "orderID": "abc",
     }
-    # get_order returns fully-matched (size_matched == size)
     inst.get_order.return_value = {
-        "size_matched": "7.0",
         "associate_trades": ["t1"],
     }
     inst.get_trades.return_value = [
@@ -414,25 +415,24 @@ def test_submit_ioc_full_match(mock_clob):
     assert fill.order_id == "abc"
     # shares_held = 7.0 * (1 - 0.10) = 6.3
     assert fill.filled_size == pytest.approx(6.3, abs=0.001)
-    inst.cancel.assert_not_called()
+    # avg_price = cost / shares = (7.0 * 0.51) / 6.3 ≈ 0.5667
+    assert fill.avg_price == pytest.approx(0.5667, abs=0.001)
+    # v2 FAK cancels remainder server-side; we never call cancel_order from submit_ioc
+    inst.cancel_order.assert_not_called()
 
 
 def test_submit_ioc_partial_match(mock_clob):
+    """FAK partial fill: only 3 of 7 shares matched; /trades reflects the partial."""
     client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    # Server says "matched" but get_order shows a smaller size_matched than
-    # we asked for — realistic response when only part of the book crossed.
-    inst.post_order.return_value = {
+    inst.create_and_post_market_order.return_value = {
         "success": True, "status": "matched", "orderID": "abc",
     }
     inst.get_order.return_value = {
-        "size_matched": "3.0",
         "associate_trades": ["t1"],
     }
     inst.get_trades.return_value = [
         {"taker_order_id": "abc", "size": "3.0", "price": "0.51", "fee_rate_bps": 1000},
     ]
-    inst.cancel.return_value = {"canceled": ["abc"]}
 
     fill = client.submit_ioc(side="up", price=0.51, size=7.0,
                              token_id="TKN-UP", condition_id="0xCOND",
@@ -441,140 +441,32 @@ def test_submit_ioc_partial_match(mock_clob):
     assert fill.status == "filled"
     assert fill.order_id == "abc"
     assert fill.filled_size == pytest.approx(2.7, abs=0.001)  # 3.0 * 0.9
-    # avg_price = cost_usdc / shares_held = (3.0 * 0.51) / (3.0 * 0.9) ≈ 0.5667
     assert fill.avg_price == pytest.approx(0.5667, abs=0.001)
-    inst.cancel.assert_called_once_with(order_id="abc")
+    inst.cancel_order.assert_not_called()
 
 
 def test_submit_ioc_no_match_returns_rejected(mock_clob):
+    """FAK with zero matches: server returns success but /trades is empty → fak-no-fill."""
     client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {
-        "success": True, "status": "unmatched", "orderID": "abc",
+    inst.create_and_post_market_order.return_value = {
+        "success": True, "status": "matched", "orderID": "abc",
     }
-    inst.get_order.return_value = {"size_matched": "0", "associate_trades": []}
-    inst.cancel.return_value = {"canceled": ["abc"]}
+    inst.get_order.return_value = {"associate_trades": []}
 
     fill = client.submit_ioc(side="up", price=0.51, size=7.0,
                              token_id="TKN-UP", condition_id="0xCOND",
                              limit_price=0.57)
 
     assert fill.status == "rejected"
-    assert fill.error == "gtc-no-fill"
+    assert fill.error == "fak-no-fill"
     assert fill.filled_size == 0.0
-    assert fill.order_id == "abc"  # persisted for reconciler
-    inst.cancel.assert_called_once()
-    # Fast path: no /trades lookup when nothing matched.
-    inst.get_trades.assert_not_called()
-
-
-def test_submit_ioc_no_match_skips_settlement_even_if_order_returns_none(mock_clob):
-    """size_matched=0 + null /order body must still return gtc-no-fill (not error).
-
-    Historically this produced `settlement-lookup: 'NoneType' object has no
-    attribute 'get'` — the fast-path now sidesteps the /trades lookup when
-    nothing matched, eliminating that race.
-    """
-    client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {
-        "success": True, "status": "unmatched", "orderID": "abc",
-    }
-    # First get_order: returns None (server hasn't indexed order yet).
-    inst.get_order.return_value = None
-    inst.cancel.return_value = {"canceled": ["abc"]}
-
-    fill = client.submit_ioc(side="up", price=0.51, size=7.0,
-                             token_id="TKN-UP", condition_id="0xCOND",
-                             limit_price=0.57)
-
-    assert fill.status == "rejected"
-    assert fill.error == "gtc-no-fill"
-    assert fill.order_id == "abc"
-    inst.get_trades.assert_not_called()
-
-
-def test_submit_ioc_settlement_failure_falls_back_to_estimate(mock_clob):
-    """When size_matched>0 and /trades lookup fails, the bot must not drop the
-    fill. Prior behavior returned `status=error` which stranded the position
-    under the rejected row; new behavior logs loudly and falls back to a
-    pessimistic estimate (shares = size_matched × (1 − fee), cost = limit)."""
-    client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {
-        "success": True, "status": "matched", "orderID": "abc",
-    }
-    # First get_order: matched partially. Second get_order (inside
-    # get_settlement_info): server hiccup.
-    inst.get_order.side_effect = [
-        {"size_matched": "7.0"},   # first call: check fully_matched
-        RuntimeError("CLOB 500"),  # second call: inside get_settlement_info
-    ]
-
-    fill = client.submit_ioc(side="up", price=0.51, size=7.0,
-                             token_id="TKN-UP", condition_id="0xCOND",
-                             limit_price=0.57)
-
-    # taker_base_fee=1000 bps -> estimate shares = 7.0 * (1 - 0.10) = 6.3
-    assert fill.status == "filled"
-    assert fill.order_id == "abc"
-    assert fill.filled_size == pytest.approx(6.3, abs=0.001)
-    assert fill.avg_price == pytest.approx(0.57)  # limit_price as pessimistic cost proxy
-    assert fill.error is None
-
-
-def test_submit_ioc_settlement_returns_none_body_falls_back_to_estimate(mock_clob):
-    """Same path as above but via the None-guard: get_settlement_info's own
-    get_order returns None → zero SettlementInfo → submit_ioc sees
-    info.shares_held=0 with size_matched>0 and falls back to estimate."""
-    client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {
-        "success": True, "status": "matched", "orderID": "abc",
-    }
-    inst.get_order.side_effect = [
-        {"size_matched": "7.0"},   # first call: check fully_matched
-        None,                      # second call: null body
-    ]
-
-    fill = client.submit_ioc(side="up", price=0.51, size=7.0,
-                             token_id="TKN-UP", condition_id="0xCOND",
-                             limit_price=0.57)
-
-    assert fill.status == "filled"
-    assert fill.order_id == "abc"
-    assert fill.filled_size == pytest.approx(6.3, abs=0.001)
-
-
-def test_get_settlement_info_handles_null_order_body(mock_clob):
-    """Bare None-guard test on get_settlement_info itself."""
-    client, inst = _make_client(mock_clob)
-    inst.get_order.return_value = None
-
-    info = client.get_settlement_info("0xOID")
-
-    assert info.shares_held == 0.0
-    assert info.cost_usdc == 0.0
-    inst.get_trades.assert_not_called()
-
-
-def test_submit_ioc_post_raises_returns_error(mock_clob):
-    client, inst = _make_client(mock_clob)
-    inst.create_market_order.side_effect = Exception("network down")
-
-    fill = client.submit_ioc(side="up", price=0.51, size=7.0,
-                             token_id="TKN-UP", condition_id="0xCOND",
-                             limit_price=0.57)
-
-    assert fill.status == "error"
-    assert "network" in fill.error
-    inst.cancel.assert_not_called()
+    assert fill.order_id == "abc"  # persisted for the reconciler
+    inst.cancel_order.assert_not_called()
 
 
 def test_submit_ioc_success_false_is_rejected(mock_clob):
     client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {
+    inst.create_and_post_market_order.return_value = {
         "success": False, "errorMsg": "fee mismatch",
     }
 
@@ -584,30 +476,42 @@ def test_submit_ioc_success_false_is_rejected(mock_clob):
 
     assert fill.status == "rejected"
     assert "fee mismatch" in fill.error
-    inst.cancel.assert_not_called()
+    inst.cancel_order.assert_not_called()
 
 
-def test_submit_ioc_cancel_fails_still_returns_fill(mock_clob):
+def test_submit_ioc_post_raises_returns_error(mock_clob):
     client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {
-        "success": True, "status": "matched", "orderID": "abc",
-    }
-    inst.get_order.return_value = {
-        "size_matched": "3.0", "associate_trades": ["t1"],
-    }
-    inst.get_trades.return_value = [
-        {"taker_order_id": "abc", "size": "3.0", "price": "0.51", "fee_rate_bps": 1000},
-    ]
-    inst.cancel.side_effect = Exception("persistent")
+    inst.create_and_post_market_order.side_effect = Exception("network down")
 
     fill = client.submit_ioc(side="up", price=0.51, size=7.0,
                              token_id="TKN-UP", condition_id="0xCOND",
                              limit_price=0.57)
 
-    # Cancel failure is logged but doesn't flip success — we have a real fill.
-    assert fill.status == "filled"
-    assert fill.filled_size == pytest.approx(2.7, abs=0.001)
+    assert fill.status == "error"
+    assert "network" in fill.error
+    inst.cancel_order.assert_not_called()
+
+
+def test_submit_ioc_settlement_lookup_failure_is_rejected(mock_clob):
+    """v2: if get_settlement_info raises, treat as rejected with a clear error.
+
+    v1's degraded-fallback estimate path is gone — without `/trades` data we
+    can't compute real cost, and v2's native FAK means there's no GTC-then-cancel
+    race window where we'd need to guess.
+    """
+    client, inst = _make_client(mock_clob)
+    inst.create_and_post_market_order.return_value = {
+        "success": True, "status": "matched", "orderID": "abc",
+    }
+    inst.get_order.side_effect = RuntimeError("CLOB 500")
+
+    fill = client.submit_ioc(side="up", price=0.51, size=7.0,
+                             token_id="TKN-UP", condition_id="0xCOND",
+                             limit_price=0.57)
+
+    assert fill.status == "rejected"
+    assert fill.order_id == "abc"
+    assert "settlement-lookup" in fill.error
 
 
 def test_submit_ioc_dry_run(mock_clob):
@@ -621,24 +525,28 @@ def test_submit_ioc_dry_run(mock_clob):
 
 def test_submit_ioc_uses_explicit_limit_price(mock_clob):
     """submit_ioc must post at the caller-supplied limit_price, not fok_limit_price(price)."""
+    from py_clob_client_v2 import OrderType, Side
     client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {
+    inst.create_and_post_market_order.return_value = {
         "success": True, "status": "matched", "orderID": "abc",
     }
-    inst.get_order.return_value = {"size_matched": "7.0", "associate_trades": []}
+    inst.get_order.return_value = {"associate_trades": []}
 
     # price=0.51, limit_price=0.42 (below same-side ask — pair-merge scenario)
     client.submit_ioc(side="up", price=0.51, size=7.0,
                       token_id="TKN-UP", condition_id="0xCOND",
                       limit_price=0.42)
 
-    args = inst.create_market_order.call_args.args[0]
+    kwargs = inst.create_and_post_market_order.call_args.kwargs
+    args = kwargs["order_args"]
     assert args.price == pytest.approx(0.42)
-    # amount is now anchored to limit_price (not price) since the server
-    # reconstructs taker = amount/limit, and that ratio must land on tick grid.
+    assert args.side == Side.BUY
+    assert args.order_type == OrderType.FAK
+    # amount is anchored to limit_price since the server reconstructs taker
+    # = amount/limit, and that ratio must land on the tick grid.
     # size_int = 7 is tick-safe for limit=0.42 (7*0.42=2.94, scaled 294.0 clean).
     assert args.amount == pytest.approx(round(7 * 0.42, 2))
+    assert kwargs["order_type"] == OrderType.FAK
 
 
 def test_tick_safe_size_picks_target_when_clean():
@@ -673,7 +581,6 @@ def test_tick_safe_size_handles_known_failing_trade_45():
     import math
     result = _tick_safe_size(12, 0.38)
     assert result is not None
-    # The returned size must survive the actual py_clob_client round_down path.
     amount = round(result * 0.38, 2)
     scaled = amount * 100
     assert math.floor(scaled) == round(scaled), (
@@ -681,68 +588,21 @@ def test_tick_safe_size_handles_known_failing_trade_45():
     )
 
 
-def test_tick_safe_size_reconstructed_ratio_is_clean_through_real_lib():
-    """End-to-end invariant: for any (size, limit) _tick_safe_size approves,
-    the real py_clob_client.get_market_order_amounts must produce a
-    maker_wei/taker_wei ratio that's a clean multiple of 0.01 — that's what
-    the server's tick-size rule actually checks. Runs for the concrete
-    historical failing pairs plus a dense sweep of the (limit, size) space
-    relevant to 5m BTC markets.
-    """
-    from py_clob_client.order_builder.builder import OrderBuilder, ROUNDING_CONFIG
-    from py_clob_client.signer import Signer
-
-    # A real OrderBuilder needs a signer and chain id, but get_market_order_amounts
-    # is purely arithmetic on its args — we just need the method.
-    signer = Signer(private_key="0x" + "1" * 64, chain_id=137)
-    builder = OrderBuilder(signer=signer, sig_type=1, funder="0x" + "2" * 40)
-    # BTC up/down markets use 0.01 ticks.
-    round_config = ROUNDING_CONFIG["0.01"]
-
-    # Historical failing cases + dense regression sweep.
-    historical = [(12, 0.38), (7, 0.58), (10, 0.67)]
-    sweep = [
-        (s, round(limit_cents / 100.0, 2))
-        for limit_cents in range(5, 95)
-        for s in range(1, 40)
-    ]
-
-    for (target_size, limit) in historical + sweep:
-        approved = _tick_safe_size(target_size, limit)
-        if approved is None:
-            # Unfixable by search window — acceptable; submit_ioc skips these.
-            continue
-        amount = round(approved * limit, 2)
-        maker_wei, taker_wei = builder.get_market_order_amounts(
-            amount, limit, round_config,
-        )
-        if taker_wei == 0:
-            continue
-        ratio = maker_wei / taker_wei
-        ratio_cents = round(ratio * 100)
-        assert abs(ratio - ratio_cents / 100) < 1e-9, (
-            f"server-side tick violation: size={approved} limit={limit} "
-            f"amount={amount} maker_wei={maker_wei} taker_wei={taker_wei} "
-            f"ratio={ratio!r}"
-        )
-
-
 def test_submit_ioc_quantizes_to_tick_safe_size(mock_clob):
-    """submit_ioc must submit an amount whose size*limit survives py_clob_client's round_down."""
+    """submit_ioc must submit an amount whose size*limit survives any round_down step."""
     import math
     client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {
+    inst.create_and_post_market_order.return_value = {
         "success": True, "status": "matched", "orderID": "abc",
     }
-    inst.get_order.return_value = {"size_matched": "9.0", "associate_trades": []}
+    inst.get_order.return_value = {"associate_trades": []}
 
     # Real failing case: size=7.49, limit=0.58 → raw ratio lands off-grid.
     client.submit_ioc(side="up", price=0.51, size=7.49,
                       token_id="TKN-UP", condition_id="0xCOND",
                       limit_price=0.58)
 
-    args = inst.create_market_order.call_args.args[0]
+    args = inst.create_and_post_market_order.call_args.kwargs["order_args"]
     scaled = args.amount * 100
     # Core invariant: floor-scaled amount equals round-scaled (no drift).
     assert math.floor(scaled) == round(scaled), (
@@ -754,39 +614,10 @@ def test_submit_ioc_quantizes_to_tick_safe_size(mock_clob):
     assert round(ratio) >= 1
 
 
-def test_submit_ioc_full_match_with_rounding_tolerance(mock_clob):
-    """size_matched=6.995 vs size=7.0: within 0.01 cents so treated as fully matched.
-
-    Server-side fee rounding can produce a floor-rounded size_matched that's
-    off by < 0.01 shares; must skip cancel (server rejects cancel of filled).
-    """
-    client, inst = _make_client(mock_clob)
-    inst.create_market_order.return_value = MagicMock()
-    inst.post_order.return_value = {
-        "success": True, "status": "matched", "orderID": "abc",
-    }
-    # size_matched is 0.005 short of 7.0 — within the 0.01 tolerance
-    inst.get_order.return_value = {
-        "size_matched": "6.995",
-        "associate_trades": ["t1"],
-    }
-    inst.get_trades.return_value = [
-        {"taker_order_id": "abc", "size": "6.995", "price": "0.51", "fee_rate_bps": 1000},
-    ]
-
-    fill = client.submit_ioc(side="up", price=0.51, size=7.0,
-                             token_id="TKN-UP", condition_id="0xCOND",
-                             limit_price=0.57)
-
-    assert fill.status == "filled"
-    inst.cancel.assert_not_called()
-
-
 def test_polymarket_client_satisfies_live_order_client_protocol():
-    """Protocol drift guard. If a future change renames an argument on
+    """Protocol drift guard. If a future change renames a method on
     PolymarketClient without updating the executor's Protocol or call sites,
-    this test catches it at import time. Phase 4's changes sit in
-    executor.py but the client's call signatures are the hot seam."""
+    this test catches it at import time."""
     for method in (
         "submit_fok", "submit_ioc", "cancel_order",
         "get_usdc_balance", "get_settlement_info", "get_order_status",


### PR DESCRIPTION
## Summary

- Polymarket's CLOB v2 cutover on 2026-04-28 bumped the EIP-712 Exchange domain version "1" → "2"; the legacy `py-clob-client==0.19.0` we were pinned to signs with the old version. Result: 4/4 gate-passing live trades on the 2026-05-15 session were rejected by the server with HTTP 400 `order_version_mismatch`.
- Swap to `py-clob-client-v2==1.0.1`. Single `create_and_post_market_order` call replaces the v1 two-step flow; `submit_ioc` becomes native `FAK` (deletes ~50 lines of v1-era GTC + manual-cancel-remainder + degraded-estimate fallback); server-side fee computation retires the `_fee_rate_bps_cache`. `SignatureTypeV2.POLY_PROXY` (= 1) preserves the existing Google-OAuth/Magic-Link proxy-wallet signing path.
- On-chain side: pUSD migration + V2 exchange allowances were done manually out-of-band before this change. Read-only balance probe (`scripts/_probe_v2_balance.py`, gitignored) confirms $41.05 pUSD visible and MAX allowance on both V2 exchange contracts (`0xE111…996B`, `0xe222…0F59`).

## Test plan

- [x] `pytest tests/` — 308/308 green; `tests/test_polymarket_client.py` 41/41 (down from 47 — six v1-only mechanics deleted).
- [x] Read-only balance probe against production CLOB returns expected pUSD balance + non-zero allowances (v2 response shape is `allowances` *map*, fixes the long-standing v1 `allowance=$0` quirk).
- [ ] Live `TRADING_MODE=live` smoke: first 3-5 gate-passing windows fill (or reject with reasons other than `order_version_mismatch` / `insufficient allowance`). Owner: bot operator post-merge.

## Notes

- Plans landed under `docs/plans/2026-05-15-clob-v2-migration-{design,implementation}.md` (cross-checked against https://docs.polymarket.com/changelog and the v2 SDK source).
- The probe scripts `scripts/probe_gtc_cancel.py` and `scripts/probe_pair_merge_limit.py` remain on legacy imports — they're off the live path and one-shot. Migrate when next reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)