### PR TITLE
fix(clients): classify v2 FAK/FOK 'no match' 400 as a clean reject

### DIFF
--- a/polypocket/clients/polymarket.py
+++ b/polypocket/clients/polymarket.py
@@ -17,6 +17,7 @@ from py_clob_client_v2 import (
     SignatureTypeV2,
     TradeParams,
 )
+from py_clob_client_v2.exceptions import PolyApiException
 
 from polypocket.config import FOK_SLIPPAGE_TICKS
 from polypocket.executor import FillResult, SettlementInfo
@@ -39,6 +40,32 @@ TICK_SIZE = "0.01"
 
 CANCEL_RETRY_MAX = 2
 CANCEL_RETRY_BACKOFF_S = 0.25
+
+
+def _classify_no_match_error(exc: Exception) -> tuple[str, str] | None:
+    """If `exc` is a v2-server no-match rejection, return (order_id, label).
+
+    Polymarket's v2 CLOB raises HTTP 400 (as a `PolyApiException`) for the
+    common case where a FOK/FAK order signs and reaches the matching engine
+    but finds no counterparty at the limit price — instead of returning a
+    normal `success: false` response body. The 400 body still carries a
+    real `orderID` we want to preserve for the reconciler.
+
+    Returns `(order_id, "fak-no-fill"|"fok-no-fill")` if the exception
+    matches that pattern, else None (caller falls back to the generic
+    `network:` error path).
+    """
+    if not isinstance(exc, PolyApiException) or exc.status_code != 400:
+        return None
+    body = exc.error_msg
+    if not isinstance(body, dict):
+        return None
+    err = (body.get("error") or "").lower()
+    if "no orders found to match" not in err:
+        return None
+    order_id = body.get("orderID") or ""
+    label = "fak-no-fill" if "fak" in err else "fok-no-fill"
+    return order_id, label
 
 
 def fok_limit_price(price: float) -> float:
@@ -153,6 +180,13 @@ class PolymarketClient:
                 order_type=OrderType.FOK,
             )
         except Exception as exc:
+            no_match = _classify_no_match_error(exc)
+            if no_match is not None:
+                order_id, label = no_match
+                return FillResult(
+                    status="rejected", order_id=order_id or None,
+                    filled_size=0.0, avg_price=None, error=label,
+                )
             log.exception("submit_fok network/signing error")
             return FillResult(
                 status="error", order_id=None, filled_size=0.0,
@@ -231,6 +265,13 @@ class PolymarketClient:
                 order_type=OrderType.FAK,
             )
         except Exception as exc:
+            no_match = _classify_no_match_error(exc)
+            if no_match is not None:
+                order_id, label = no_match
+                return FillResult(
+                    status="rejected", order_id=order_id or None,
+                    filled_size=0.0, avg_price=None, error=label,
+                )
             log.exception("submit_ioc network/signing error")
             return FillResult(
                 status="error", order_id=None, filled_size=0.0,

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -133,6 +133,49 @@ def test_submit_fok_network_error(mock_clob):
     assert "boom" in fill.error
 
 
+def test_submit_fok_no_match_400_classified_as_rejected(mock_clob):
+    """v2 server raises PolyApiException(status=400) when FOK finds no match,
+    even though the body carries a real orderID. Must surface as a clean
+    `fok-no-fill` rejection with the orderID preserved (not as `status=error`).
+    """
+    from py_clob_client_v2.exceptions import PolyApiException
+    client, inst = _make_client(mock_clob)
+    exc = PolyApiException.__new__(PolyApiException)
+    exc.status_code = 400
+    exc.error_msg = {
+        "error": "no orders found to match with FOK order. FOK requires immediate full fill.",
+        "orderID": "0xABCDEF",
+    }
+    inst.create_and_post_market_order.side_effect = exc
+
+    fill = client.submit_fok(side="up", price=0.51, size=7.0,
+                             token_id="TKN-UP", condition_id="0xCOND")
+
+    assert fill.status == "rejected"
+    assert fill.error == "fok-no-fill"
+    assert fill.order_id == "0xABCDEF"  # preserved for the reconciler
+    assert fill.filled_size == 0.0
+
+
+def test_submit_fok_other_400_still_errors(mock_clob):
+    """A 400 that's not a no-match (e.g., insufficient balance) must still
+    fall through to the generic network error path — we don't want to mask
+    real failures as no-fills."""
+    from py_clob_client_v2.exceptions import PolyApiException
+    client, inst = _make_client(mock_clob)
+    exc = PolyApiException.__new__(PolyApiException)
+    exc.status_code = 400
+    exc.error_msg = {"error": "not enough balance / allowance"}
+    inst.create_and_post_market_order.side_effect = exc
+
+    fill = client.submit_fok(side="up", price=0.51, size=7.0,
+                             token_id="TKN-UP", condition_id="0xCOND")
+
+    assert fill.status == "error"
+    assert "network:" in fill.error
+    assert "balance" in fill.error
+
+
 def test_submit_fok_dry_run_does_not_post(mock_clob):
     client, inst = _make_client(mock_clob, dry_run=True)
 
@@ -490,6 +533,54 @@ def test_submit_ioc_post_raises_returns_error(mock_clob):
     assert fill.status == "error"
     assert "network" in fill.error
     inst.cancel_order.assert_not_called()
+
+
+def test_submit_ioc_no_match_400_classified_as_rejected(mock_clob):
+    """v2 server raises PolyApiException(status=400) when FAK finds no match.
+    Real-world example from 2026-05-15 live session — must surface as
+    `fak-no-fill` with orderID preserved (not as `status=error`).
+    """
+    from py_clob_client_v2.exceptions import PolyApiException
+    client, inst = _make_client(mock_clob)
+    exc = PolyApiException.__new__(PolyApiException)
+    exc.status_code = 400
+    exc.error_msg = {
+        "error": ("no orders found to match with FAK order. FAK orders "
+                  "are partially filled or killed if no match is found."),
+        "orderID": "0xea9b4792d52161bc",
+    }
+    inst.create_and_post_market_order.side_effect = exc
+
+    fill = client.submit_ioc(side="up", price=0.51, size=7.0,
+                             token_id="TKN-UP", condition_id="0xCOND",
+                             limit_price=0.57)
+
+    assert fill.status == "rejected"
+    assert fill.error == "fak-no-fill"
+    assert fill.order_id == "0xea9b4792d52161bc"
+    assert fill.filled_size == 0.0
+    inst.cancel_order.assert_not_called()
+
+
+def test_submit_ioc_no_match_with_empty_order_id(mock_clob):
+    """Defensive: if the 400 body somehow omits orderID, treat order_id=None
+    (not the empty string) so executor doesn't write a bogus link."""
+    from py_clob_client_v2.exceptions import PolyApiException
+    client, inst = _make_client(mock_clob)
+    exc = PolyApiException.__new__(PolyApiException)
+    exc.status_code = 400
+    exc.error_msg = {
+        "error": "no orders found to match with FAK order.",
+    }
+    inst.create_and_post_market_order.side_effect = exc
+
+    fill = client.submit_ioc(side="up", price=0.51, size=7.0,
+                             token_id="TKN-UP", condition_id="0xCOND",
+                             limit_price=0.57)
+
+    assert fill.status == "rejected"
+    assert fill.error == "fak-no-fill"
+    assert fill.order_id is None
 
 
 def test_submit_ioc_settlement_lookup_failure_is_rejected(mock_clob):


### PR DESCRIPTION
## Summary

Polymarket's v2 CLOB raises `PolyApiException(status_code=400)` when a FAK or FOK order signs cleanly and reaches the matching engine but finds no counterparty at the limit price — instead of returning a normal `success: false` response body. The 400 body still carries a real `orderID`.

Pre-fix, that exception fell into `submit_fok` / `submit_ioc`'s generic `network: <exc>` branch, marking these as `status="error"` with a `PolyApiException` prefix in the trades table and dropping the `order_id` linkage that the startup stranded-fill reconciler relies on. Observed 4× in the 2026-05-15 live session post-migration (trades #7, #8, #9, #12).

This change adds a small `_classify_no_match_error(exc)` helper that inspects the 400 body and returns `(order_id, "fak-no-fill"|"fok-no-fill")` for matching cases. Both submit paths use it before falling through to the existing generic error branch. Real-failure 400s (insufficient balance, banned address, tick-size violation) keep going through the `network:` path untouched.

## Test plan

- [x] `pytest tests/` — 312/312 green (was 308; +4 tests for the new error path).
- [x] New tests cover: FAK no-match classified as `fak-no-fill` with order_id preserved; FOK no-match classified as `fok-no-fill`; defensive empty-orderID handling; non-no-match 400s still surface as `network:` errors.
- [ ] Live verification: next FAK that hits "no orders found to match" should land as `status='rejected'`, `error='fak-no-fill'`, with the real order_id populated. Owner: bot operator on next applicable window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)