### PR TITLE
feat: post-only / maker-side entry path behind ENTRY_MODE flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ corpus*.parquet
 # Generated PnL attribution reports (committed sample is whitelisted on first run only).
 scripts/_pnl_attribution.md
 
+# Generated post-only replay reports (committed sample is whitelisted on first run only).
+scripts/_post_only_replay.md
+
 # Throwaway probe scripts — never commit.
 scripts/_probe_*.py

--- a/docs/plans/2026-05-15-post-only-entries-design.md
+++ b/docs/plans/2026-05-15-post-only-entries-design.md
@@ -1,0 +1,279 @@
+# Post-only / maker-side entries — design
+
+**Date:** 2026-05-15
+**Companion:** `2026-05-15-post-only-entries-implementation.md` (not yet drafted; gated on human review of this doc)
+**Depends on:** `polymarket_clob_v2_migration` (shipped, commit ~a98e76c) — native FAK now lives on v2; post-only requires the v2 SDK's `post_only=True` flag.
+**Closes (if shipped):** the structural side of the live-v2 execution gap diagnosed 2026-05-16 (see memory `project_live_v2_execution_gap`).
+
+## Problem
+
+First v2 live cohort (n=20) showed live calibration ~11.7 pts UNDER paper on the DOWN side at identical model + UTC band. The diagnostic landed on the execution seam: when our FAK reached the matcher 1–2 s after sign, the top-of-book opp-side liquidity it was supposed to cross against was *gone* (raced / cancelled / illusory). The four cleanest ack-time-book proxies showed near-zero drift; the FAK simply found nothing at-or-below limit and rejected. This is the **vanishing-liquidity-at-cross** failure mode — distinct from "book moved past limit", and **not fixable by widening the IOC buffer** (a wider buffer doesn't conjure depth that isn't there).
+
+The structural fix is to stop racing for thin top-of-book and instead *provide* the liquidity others race for: rest a maker order one tick below the pair-merge clearing and let counterparties cross to us. Trades that fill earn the same edge the gate signed off on (plus a tick or two of price improvement); trades that don't fill leave us in cash. The current FAK regime trades fill certainty for execution-seam risk; the post-only regime trades fill certainty for **adverse selection** risk — a different bias with a different fix.
+
+This plan does not modify the model, the gate, the sizing, or the risk manager. It adds a second execution mode behind a config flag, leaves FAK in place, and stages a clean A/B.
+
+## Goal
+
+Ship a `submit_post_only` execution path that:
+- Sits behind `ENTRY_MODE=fak|post_only` (default `fak`; flip per process / per cohort).
+- Posts a GTC + `post_only=True` order at `(1 − best_opp_bid) − POST_ONLY_REST_OFFSET_TICKS` (default: 1 tick below the pair-merge clearing).
+- Carries a server-side `expiration` tied to window-close minus a safety buffer.
+- Cancels at `WINDOW_ENTRY_MIN_REMAINING` on the bot tick as belt-and-braces.
+- Records `place / fill / cancel / reject` events in `order_events` and reconciles the trade row to the final filled VWAP at cancel-or-expire.
+- Honors partial fills, the stranded-fill sweep, and crash-recovery.
+- Tags every trade row with `entry_mode` so PnL attribution / model_health can cohort FAK vs post-only.
+
+Out of scope (deliberately) is changing the gate, changing the cushion, changing sizing, or changing paper-mode mechanics. Paper continues to fill instantaneously at `entry_price = ask`; post-only is a live-only construct and the live-vs-paper calibration delta is the validation knob, not paper itself.
+
+## Key design questions
+
+### 1. Where do we rest?
+
+**Recommendation:** rest at `pmc − POST_ONLY_REST_OFFSET_TICKS` where `pmc = 1 − best_opp_bid` and the default offset is **2 ticks**.
+
+Offset=2 is a deliberate compromise. Offset=1 (the most aggressive non-crossing rest) maximizes captured edge but exposes us to a known concrete failure: typical book staleness between gate-evaluation and SDK signing is ~200–500 ms, during which pmc can drift by 1 tick — at offset=1 that drift causes immediate post-only-cross rejection. Offset=3+ gives more drift safety but at proportionally lower fill rate. Offset=2 absorbs typical drift while still capturing ~7 ticks of price improvement over the FAK regime's `pmc + 8`.
+
+The first-cohort goal is to answer "does live calibration converge to paper under maker fills" — that is answerable at any offset; offset=1 doesn't help that question, it just maximizes adverse-selection variance. The knob is plumbed so a follow-up cohort can sweep it.
+
+Tradeoffs across the three candidate strategies:
+
+| Strategy | Rest price | Fill condition | Pros | Cons |
+|---|---|---|---|---|
+| **pmc − 1 tick** *(recommended)* | One tick below the current pair-merge cross | Best opp-bid bumps up ≥1 tick (opp-side becomes more aggressive) OR a same-side SELL taker arrives at-or-below our limit | Most aggressive non-crossing rest; ~9 ticks of free price improvement over the FAK regime (since the FAK limit was `pmc + 8`); EV-positive on a much wider range of opp-side movement than a deeper rest | Highest adverse-selection exposure: fills happen *exactly when the implied clearing has moved toward us*, which is the regime most correlated with "the underlying is moving the way our signal predicted" — modest positive bias — OR "DOWN-side just got aggressively bid", which is signal-against |
+| **Pair-merge clearing exactly (`pmc`)** | Right at the cross | Would-cross on placement → post-only **rejected** by server | Conceptually clean — sits at the price the gate already approved at the cushion floor | Doesn't actually rest; turns into an immediate-cancel signal |
+| **Best-bid-on-our-side + 1 (`best_up_bid + 1`)** for BUY UP | Joins our own side's queue, top of new level | Same-side SELL taker arrives at our limit (rare on binary books — SELL-into-bids is uncommon vs the pair-merge path) OR opp side bumps enough to cross through `best_up_bid + 1` | Maximizes own-side queue position; price-improving | On binary books most flow is pair-merge, not same-side SELL — joining the own-side queue is a queue we don't actually want to be in. Empirically `best_up_bid` is bounded below `pmc` by no-cross, so this is always ≤ `pmc − 1`, i.e. equal-or-worse than the recommended rest for fill purposes, and worse on adverse selection |
+| **Decision-time pair-merge (`pmc + cushion`)** | At the level the gate signed off on | Same as pmc but with cushion baked in | The cushion is a FAK-era reject buffer; against a resting maker, all it does is push our rest deeper into the book (further from cross), which lowers fill rate without changing realized fill price | A deeper rest is strictly conservative. We can ship that as a v2 variant; v1 ships the most-aggressive non-crossing rest |
+
+The single tunable (`POST_ONLY_REST_OFFSET_TICKS`, default 1) lets us slide along the fill-rate vs adverse-selection frontier later without restructuring code.
+
+### 2. What happens to the 8¢ signal cushion?
+
+The cushion (`SIGNAL_CUSHION_TICKS = 8`) currently does two things, conflated:
+1. **FAK reject buffer:** the FAK limit price was `pmc + 8` to absorb 8 ticks of DOWN-bid drift between sign and ack.
+2. **Gate selectivity floor:** the gate computes `edge = model_p_up − effective_ask(pmc + 0.08)`, so a 10¢ edge over the cushioned price is the actual MIN_EDGE bar.
+
+For post-only, role (1) is irrelevant: we never trade at a price the gate didn't approve, because we rest at `pmc − 1` which is 9 ticks more favorable than `pmc + 8`. Role (2) — selectivity — remains. The cushion still controls *which signals fire*; under post-only it stops controlling *what price we accept*.
+
+**Recommendation: leave the cushion in the gate unchanged for v1.** Filled post-only trades earn ~9 ticks of "free" edge above what the gate scored. This is conservative — under-counts our edge, doesn't fire trades we shouldn't fire. After a paper-validated cohort, we can re-cohort selectivity (lower the cushion to widen the funnel) independently.
+
+PnL attribution will need to be aware: the `signal_reference_price` stored on the trade row remains `pmc + cushion` (computed in `signal._effective_entry`, unchanged), but the realized `entry_price` will be ~`pmc − 1` on post-only fills. The diagnostic that "slip = sig_ref − entry_price = +0.080 across all live trades" will be a different number in the post-only cohort — slip will be ~+0.09 ($+9¢) on filled post-only trades, meaning the **realized fill came in 9¢ better than the gate's reference**. That's information, not a bug — but it inverts the slip-sign convention from the 2026-05-11 attribution design ("slip ≤ 0 in expectation under buffer-above-mid"). The PnL attribution doc (`docs/plans/2026-05-11-pnl-attribution-design.md` §"Interpretation") will need a cohort-aware reading once post-only cohorts exist — the `entry_mode` column on `trades` makes that split trivial. The new `rest_price` column persisted alongside `signal_reference_price` gives attribution a clean two-axis decompose: `(sig_ref − rest_price)` is the gate's "give-back-to-cushion" (always positive for post-only at the recommended offset), `(rest_price − entry_price)` is the actual rest-vs-fill drift (≈ 0 for post-only by construction). No code change to attribution belongs in this plan — flagged as follow-up.
+
+### 3. Order type and SDK call — confirmed
+
+`py_clob_client_v2` source (`client.py:829–841`):
+
+```python
+def create_and_post_order(
+    self,
+    order_args: OrderArgsV2,
+    options: PartialCreateOrderOptions = None,
+    order_type: OrderType = OrderType.GTC,
+    post_only: bool = False,
+    defer_exec: bool = False,
+):
+    return self._retry_on_version_update(
+        lambda: self.post_order(
+            self.create_order(order_args, options), order_type, post_only, defer_exec
+        )
+    )
+```
+
+with `post_order` (`client.py:856–883`) explicitly:
+
+```python
+if post_only and order_type in (OrderType.FOK, OrderType.FAK):
+    raise ValueError("post_only is not supported for FOK/FAK orders")
+```
+
+So post-only **must** use `OrderType.GTC` (or `OrderType.GTD` for an additional time-bound semantic — see Q5 / `expiration`). The SDK client-side enforces "no post-only on market orders"; the server enforces post-only crossing rejection.
+
+`OrderArgsV2` (`clob_types.py:75`):
+- `token_id, price, side, size` (size in **shares**, not USDC — important: this differs from `MarketOrderArgsV2.amount` which is USDC for BUY).
+- `expiration: int = 0` (Unix timestamp, 0 = no expiration).
+- `builder_code, metadata, user_usdc_balance` — we don't use these.
+
+When the order would cross, the **server** returns the rejection (not the SDK). Empirical confirmation of the error shape is a Step-1 verification task in the implementation plan (likely `success: false, errorMsg: "post_only_would_cross"` or similar HTTP-400 PolyApiException; the v2-server precedent for FAK no-match was a 400 with `{"error": "no orders found to match"}`). The `_classify_no_match_error` helper in `clients/polymarket.py` will need a sibling for the post-only-cross case so we surface a clean `error="post-only-would-cross"` rather than a generic `network:` string.
+
+### 4. Cancel-on-timeout
+
+Two layers, server-side and bot-side, with the bot-side being authoritative:
+
+- **Server-side `expiration`** on `OrderArgsV2.expiration`: set to `window.end_time − POST_ONLY_EXPIRY_SAFETY_BUFFER_S` (default 30 s). If the bot crashes, the server auto-kills the order at this timestamp. This is defense-in-depth — it does *not* free us from doing our own cancel.
+- **Bot-side cancel** in `_on_book_update`: on each tick, if `self._open_trade` is a post-only resting order (status `placed`) and `t_remaining ≤ POST_ONLY_CANCEL_AT_T_REMAINING_S` (default 30 s), call `client.cancel_order(order_id)` then `client.get_settlement_info(order_id)` to reconcile partial fills.
+
+**Trigger:** wall-clock `t_remaining ≤ 30 s`, full stop, not mid-window mid-moves or signal staleness. Mid-window re-evaluation (cancel-and-repost when pmc moves K ticks, cancel when signal flips) is a v2 enhancement explicitly **out of scope** for v1. The simplest possible lifecycle is: one place, one cancel-or-fill, no repost. Multi-shot reposting changes the n=trades semantics (does a re-posted-after-move order count as one decision or two?), and we'd rather measure the single-shot version first.
+
+The choice of 30 s mirrors `WINDOW_ENTRY_MIN_REMAINING` (the gate's signal-acceptance band-end). Filling inside the last 30 s would have us holding a position with no time for the signal to play out, in the regime the gate already deems unsafe to *enter*.
+
+### 5. Cancel-on-window-close
+
+The bot-side tick-driven cancel above runs in `_on_book_update`, which fires on every book event during the live window. Two failure modes for tick-driven cancel:
+- **Bot is silent at the cancel deadline** (no book events for >30 s near window-end). Mitigated by the `MAX_BOOK_AGE_S = 3.0` staleness gate already running — but that gate refuses new trades, it doesn't cancel resting ones. Bridging: the server-side `expiration` covers this case. Order dies even if bot doesn't see the boundary.
+- **Window-transition firing during cancel processing.** `_on_book_update` advances the window before checking `self._open_trade`; the cancel logic must guard against trying to cancel an order whose status has already been reconciled by the transition.
+
+**Polymarket does not "auto-expire on window resolution"** — its `expiration` field is wall-clock-only. The bot must drive cancel; the server's expiration is the safety net.
+
+Crash-recovery: if a resting order survived a bot restart into a new window, `reconcile_recovered_trade` needs a new branch for CLOB status `"live"` (= still resting on server). Today the reconciler handles `"matched"`, `"canceled" / "cancelled" / "unmatched"`, and unknown. A live order from a stale window should be cancelled-then-reconciled explicitly during recovery — the window context is gone so we should not let it sit and potentially fill.
+
+### 6. Partial-fill handling
+
+Post-only's chief lifecycle complication. Three states across one order's life:
+
+```
+place → (placed, 0 filled) → tick 1 fill 10 shares → (placed, 10 filled)
+       → tick 2 fill 15 shares → (placed, 25 filled)
+       → cancel (or window-end) → (cancelled, 25 filled, 5 unfilled)
+```
+
+We do not need real-time fill detection in v1. The deciding moment is **cancel/expire**: at that point we query `get_settlement_info(order_id)` and learn the final cumulative `shares_held` + `cost_usdc`. The trade row is updated once:
+
+- `shares_held > 0`: status → `open` (continues to settlement at window-close), `size = shares_held`, `entry_price = cost_usdc / shares_held`. This is identical to FAK's partial-fill path — the existing settle flow already handles it.
+- `shares_held == 0`: status → `rejected`, `error = "post-only-no-fill"`.
+
+While the order is resting (between place and cancel), the trade row stays at `status = "placed"` with `size = intended_size` and `entry_price = rest_price` — the *intended* values, not the realized ones. This mirrors how `status = "reserved"` works for the FAK path today (intended size/price persisted; overwritten on actual fill).
+
+We optionally write a `fill` event per partial in `order_events` for diagnostic richness, but the trade row reconciles once at cancel — not per partial. Rationale: per-partial trade-row updates require either polling (expensive) or a websocket fill-feed (more SDK surface than we want to take on for v1). One reconciliation at cancel is sufficient for correct sizing/PnL.
+
+**Dust threshold:** the existing `execute_live_trade` warns when `filled_size * avg_price < MIN_POSITION_USDC * 0.25`. Reuse this on post-only's cancel-reconcile path. Below that floor the position is still settled in the normal flow (we don't try to refund); we just log it loudly.
+
+### 7. Config flag and constants
+
+New env-backed constants in `polypocket/config.py`:
+
+| Constant | Default | Purpose |
+|---|---|---|
+| `ENTRY_MODE` | `"fak"` | `"fak"` keeps current path; `"post_only"` switches to new path. Read in `bot.py`. |
+| `POST_ONLY_REST_OFFSET_TICKS` | `2` | Ticks below pmc to rest. Default absorbs typical sub-second pmc drift between gate-eval and SDK sign while still capturing ~7 ticks of edge over FAK's `pmc + 8`. Tune later from cohort data. |
+| `POST_ONLY_CANCEL_AT_T_REMAINING_S` | `30` | Bot-side cancel deadline. Matches `WINDOW_ENTRY_MIN_REMAINING`. |
+| `POST_ONLY_EXPIRY_SAFETY_BUFFER_S` | `30` | Subtracted from `window.end_time` for server-side `expiration`. Same value as the bot deadline by design. |
+
+**Every one of these must be added to `tests/conftest.py::_key`** — failure to do so leaks the developer's `.env` into CI (per `project-context.md`'s "single most common silent bug vector"). This is the load-bearing change to the test plumbing.
+
+Append the same names to `snapshot_gate_config()` so `gate_config_json` on `decision` snapshots records the active entry mode and offset for every trade.
+
+### 8. Order-events lifecycle
+
+Today FAK writes 4 event types: `submit → ack → (fill | reject)`. Post-only mirrors that shape — same five-type alphabet — instead of inventing a new dialect:
+
+| Event | When | Payload |
+|---|---|---|
+| `place` | Before `client.submit_post_only` call. Analogue of FAK `submit`, but the order rests instead of crossing. | side, intended_size, rest_price, expiration, signal_reference_price, book_age_s_monotonic |
+| `ack` | Immediately after the SDK call returns | status (`"placed"` or `"rejected"`), success, order_id, error (if any) |
+| `fill` | Each detected partial fill (best-effort; v1 derives at cancel-time, not in-flight) | this_fill_size, this_fill_price, cumulative_size, cumulative_cost |
+| `cancel` | Bot or reconciler issues cancel | trigger ∈ {`window-close`, `crash-recovery`, `manual`}, cancel_success, final_shares_held, final_cost_usdc, retries |
+| `reject` | Post-only would have crossed at placement (terminal) | error = `"post-only-would-cross"`, current pmc snapshot |
+
+Net: existing analysis joins on `event_type IN ('submit','ack','fill','reject')` add `'place'` and `'cancel'`; nothing already-written changes meaning. The `submit` vs `place` naming distinction is load-bearing — it lets a cohort query split FAK-attempts from post-only-attempts without a join through `trades.entry_mode`.
+
+### 9. Telemetry
+
+New fields:
+
+- **`trades.entry_mode TEXT`** — `"fak"` or `"post_only"`. Idempotent ALTER on `init_db`. Populated by both executor paths.
+- **`trades.rest_price REAL`** *(post-only only; nullable)* — the price we rested at, distinct from `entry_price` (which on a partial fill is the realized VWAP). For FAK rows this stays NULL.
+- **`order_events.payload_json`** already supports arbitrary keys — no schema change there.
+
+New analyses (out of scope to write here; documented as follow-ups):
+
+- **Cohort fill rate**: `% placed → filled` per entry_mode, daily and rolling.
+- **Cohort latency**: median ms from `place` to first `fill`.
+- **Cohort calibration**: per-bin reliability split by entry_mode in `scripts/model_health.py`. The same script that surfaced the live-vs-paper gap is what closes the validation loop here.
+- **Adverse-selection probe**: for filled post-only trades, persist book state at fill-time (already covered by `book_at_ack`'s sibling — extend the `_book_top_n` snapshot pattern to fill events) and compute the cross-of-rest-price vs cross-at-fill-time gap.
+
+### 10. What can break
+
+| Failure mode | Severity | Mitigation |
+|---|---|---|
+| **Adverse selection** — book moves against signal between place and fill; we get picked off at a now-unfavorable price. This is the dominant new failure mode and is structural, not a bug. | High (expected) | Single-shot rest with `expiration ≤ 30 s before window-close` caps exposure to the window's remaining vol. Bot-side cancel at `t_remaining = 30 s` is faster than server expiry. Future v2: cancel-and-repost on pmc-move ≥ K ticks. |
+| **Cancel race**: bot fires cancel, fill lands 50 ms before cancel reaches server. Server fills partial, then cancels. | Medium | Always call `get_settlement_info(order_id)` after `cancel_order` returns, regardless of cancel's success flag. The post-cancel CLOB state is authoritative. |
+| **Ghost fill**: bot thinks cancel succeeded with 0 shares; actually order fully filled before cancel reached server, we miss recording the position. | Medium | Same mitigation: post-cancel `get_settlement_info`. If `shares_held > 0`, promote trade to `open`, settle normally. This is the stranded-fill-sweep pattern, applied at cancel time instead of recovery time. |
+| **Cross-window resting order on crash-recovery**: bot died mid-rest. Server expiration may or may not have fired by recovery time. | Medium | `reconcile_recovered_trade` learns a new branch: if `/order` says `"live"`, call `cancel_order` explicitly, then `get_settlement_info`, then promote/reject per shares_held. Don't let a stale-window order keep resting. |
+| **Settlement under partial fills**: window resolves with a partial position. | Low | `settle_live_trade` already reads `shares_held` and `cost_usdc` from the CLOB at settle-time. Works unchanged. Path simply scales by `shares_held` instead of `intended_size`. |
+| **Dust position from partial fill**: e.g., $1 filled of a $10 intended order. | Low | Reuse the existing dust-warn line in `execute_live_trade` (`notional < MIN_POSITION_USDC * 0.25`). Log loud; settle normal. |
+| **Post-only rejection on placement (would-cross)**: pmc moved by ≥ `POST_ONLY_REST_OFFSET_TICKS` between gate decision and SDK call. | Low | Server returns rejection. Trade row goes to `status = "rejected"`, error `"post-only-would-cross"`, window consumed. Same shape as FAK's `"fak-no-fill"`. Frequency expected to be low at offset=1; will rise if we tune offset down to 0. |
+| **`OrderArgsV2.size` units bug**: this path passes shares (not USDC) where FAK passed USDC. Easy to confuse. | Medium | Single integration test with a hand-computed size+price → expected JSON payload. Code path runs through `_tick_safe_size` as defense-in-depth (it's a no-op on the share dimension but a check on `size * limit`). |
+| **`expiration` units bug**: Unix seconds, not millis; bot computes from `window.end_time` (already Unix seconds). | Low | Type-check in tests; one passing test asserts the JSON payload's expiration is an int and matches `int(window.end_time - 30)`. |
+| **TUI keybind mutates `POST_ONLY_REST_OFFSET_TICKS` mid-window**: existing TUI keybind contract treats config constants as live references. If the user re-tunes mid-rest, the next *new* order picks up the new value; the resting order is unaffected. | Low | Standard pattern. No change needed; verify in passing. |
+| **Paper mode silently broken**: post-only is a live concept. Paper continues as today. | Low | `bot.py` only routes post-only when `TRADING_MODE != "paper"`. The `ENTRY_MODE` flag is read but ignored in paper. Single test confirms. |
+
+## Files touched (preview)
+
+| File | Change |
+|---|---|
+| `polypocket/config.py` | Add `ENTRY_MODE`, `POST_ONLY_REST_OFFSET_TICKS`, `POST_ONLY_CANCEL_AT_T_REMAINING_S`, `POST_ONLY_EXPIRY_SAFETY_BUFFER_S`. Add to `snapshot_gate_config()`. |
+| `tests/conftest.py` | Append the four env keys to `_key` tuple. |
+| `polypocket/ledger.py` | Idempotent ALTER on `trades`: add `entry_mode TEXT`, `rest_price REAL`. Plumb both through `log_trade` (defaulted nullable). |
+| `polypocket/clients/polymarket.py` | New `post_only_rest_price(side, up_bids, down_bids, offset_ticks) -> float \| None` pure helper next to `ioc_limit_price`. New `submit_post_only` method on `PolymarketClient`. New `_classify_post_only_cross_error` helper. |
+| `polypocket/executor.py` | Extend `LiveOrderClient` Protocol with `submit_post_only`. New `PlaceResult` frozen dataclass (status ∈ `"placed"`, `"rejected"`, `"error"`). New `execute_live_trade_post_only` function. **Place-time pmc recompute inside this function**: the caller passes the gate-time bids alongside fresh `client.get_order_book` results; rest_price is recomputed against the freshest book right before signing, so place-time pmc drift between gate-eval and signing does not silently produce a stale-price cross-and-reject. Extend `reconcile_recovered_trade` for `"live"` CLOB status. |
+| `scripts/replay_post_only_paper.py` *(new)* | Post-hoc replay: read `paper_trades.db` `decision` snapshots, compute the hypothetical post-only rest_price from persisted bids JSON, walk forward through `window_book_samples` for the same window_slug to determine fill outcome (filled iff any sample shows `best_opp_bid ≥ 1 − rest_price`), emit `scripts/_post_only_replay.md` with fill rate, fill price distribution, and would-have-been calibration per `entry_mode='post_only'` cohort. Read-only — does not write to the DB. |
+| `polypocket/bot.py` | Read `ENTRY_MODE`. Dispatch in the live branch. New `_cancel_resting_order` helper called on each tick when post-only order is open and `t_remaining ≤ POST_ONLY_CANCEL_AT_T_REMAINING_S`. **Add `"placed"` to the live-mode `recoverable_statuses` set** so a resting order survives bot restart through the existing reconciler hook. |
+| `tests/test_executor.py`, `tests/test_polymarket_client.py`, `tests/test_bot.py`, `tests/test_signal.py` | New tests. See implementation plan §"Test plan". |
+
+Untouched by design: `signal.py` (gate logic unchanged), `risk.py`, `feeds/`, `observer.py`, `backtester.py`, `fillmodel.py` (paper is unaffected), `analyze.py`, `model_health.py` (cohort splits happen via the new `entry_mode` column — pure-read changes, easy follow-ups, not bundled into this PR).
+
+## Validation plan
+
+### Honoring the memory's plan — post-hoc replay, not real-time paper execution
+
+The diagnostic memory (`project_live_v2_execution_gap`) prescribes:
+
+> "Validation plan when post-only lands: **3-5 days paper validation watching fill rate (will be lower than FAK — acceptable), fill prices (must land at resting limit), and paper v2 calibration under maker path.** Then small live rollout at $5/trade with the new ack-time book diagnostic."
+
+A literal reading of "paper validation watching fill rate" implies adding a post-only execution path to paper mode — defer settlement, track resting state, model when a rest "fills" against a moving book. That doubles the bot's lifecycle surface area (four paths instead of two), and any synthesized fill probability would be calibrated against FAK-era live data whose execution seam is the bug we're escaping.
+
+This plan honors the memory's intent via a smaller, more honest mechanism: **post-hoc replay against the existing `window_book_samples` table.** The bot's runtime paper path stays unchanged (FAK-shape, instant ask fill). After-the-fact, `scripts/replay_post_only_paper.py` reads paper decisions, computes the hypothetical rest_price at the current `POST_ONLY_REST_OFFSET_TICKS`, walks the 30-second-cadence book samples forward through the window, and marks a fill iff any sample shows `best_opp_bid ≥ 1 − rest_price` before the cancel boundary. Outputs:
+
+- **Fill rate** (count of "would have filled" / count of "would have placed").
+- **Fill timing** (median sample-index at first fill).
+- **Calibration** under the hypothetical post-only cohort, joined to the existing `outcome` resolution per window.
+
+This is deterministic over real recorded book data — no synthesized fillmodel, no encoded assumptions. It under-counts intra-30s fills (book samples are coarse) so the reported fill rate is a lower bound. It cannot observe adverse selection that would emerge from post-only's *presence* on the book changing other actors' behavior — only live can. But it answers the memory's three load-bearing questions ("fill rate", "fill prices land at limit", "paper calibration under maker path") at a fraction of the runtime work.
+
+The live cohort at $5/trade remains the authoritative test of the execution-seam fix. The replay is the cheap pre-flight check that buys confidence in the new code paths before money goes in.
+
+### Phases
+
+**Phase 1 (mandatory before ship):** structural validation in paper mode. The new code paths must not crash, the new config flag must round-trip through `snapshot_gate_config`, the new ledger columns must persist, and **the FAK path must remain bit-identical** when `ENTRY_MODE=fak`. Test suite green. Paper trades continue to fill at ask — `ENTRY_MODE` is read but the live-only post-only branch is never entered in paper.
+
+**Phase 2 (mandatory before live promotion):** post-hoc replay against current `paper_trades.db`. Run `scripts/replay_post_only_paper.py` against all decisions with non-null bids JSON. Acceptance:
+- Fill rate is a plausible number (not 0%, not 100%). Below ~15% is a signal the offset is too deep; above ~80% is a signal the offset is too aggressive (probably crossing immediately and rejecting in real life).
+- Reported calibration on the would-have-filled cohort is closer to (or at least no worse than) paper's existing FAK-equivalent calibration. If post-only replay surfaces a calibration *worse* than paper FAK, that's a flag to investigate before going live — paper book samples are the same data source for both.
+
+**Phase 3 (mandatory before live promotion):** dry-run live probe. One single-shot post-only placement against a real BTC up/down market, off the bot, at minimum size. Verify: order id returned, server reports `success: true status: "live"`, the order shows up via `/order` lookup at the expected rest price, the bot can cancel it, post-cancel `get_settlement_info` returns shares_held=0 / cost_usdc=0. Document the exact server response shape for both success and would-cross failure in the implementation plan's Step 7 acceptance log.
+
+**Phase 4 (recommended; small live cohort):** 50-100 live trades at `MIN_POSITION_USDC = 5` to validate the calibration premise empirically. Measure:
+- Fill rate: compare to Phase-2 replay's lower-bound estimate. Live should be at-or-above the replay number (since live observes intra-30s fills the replay misses). A live fill rate materially *below* the replay is a flag — suggests post-only's presence on the book is changing other actors' behavior in a way that suppresses fills.
+- Realized entry vs rest price: expect entry ≈ rest (no slip in either direction since post-only fills only at rest).
+- Live calibration vs paper: target gap closure on the DOWN bin — from the diagnostic's −11.7pt back to within ±3pt of paper.
+
+**Phase 5 (out of scope here):** if Phase 4 closes the gap, promote default to `ENTRY_MODE=post_only`. If Phase 4 surfaces adverse selection as a new dominant cost (fills concentrate on the wrong side of book moves), iterate on `POST_ONLY_REST_OFFSET_TICKS` or design the v2 cancel-and-repost extension. If Phase 4 fails to close the gap at all, that's evidence the live-side post-only execution still misses something the replay didn't catch — investigate from a position of having the cohort data.
+
+## What this deliberately does NOT do
+
+- **Does not change the gate, the cushion, MIN_EDGE_THRESHOLD, MIN_MODEL_CONFIDENCE, or sizing.** The gate runs identically; only the execution path downstream differs.
+- **Does not implement cancel-and-repost on book-moves.** Single-shot rest only. Multi-shot is the obvious v2 enhancement once we see how often book-move-during-rest matters.
+- **Does not implement signal-staleness cancel.** The bot does not re-evaluate the signal during the rest period to decide whether to cancel. Window-close is the only programmed cancel trigger.
+- **Does not change paper mode.** Paper continues to fill at ask, instantly. Paper-vs-live calibration validation is structural (does the new code run?) not economic (does the rest-fill timing match?). The diagnostic memo's conclusion that paper is the source of truth for the model still holds; paper is **not** the test bed for post-only's fill economics.
+- **Does not implement a websocket fill feed.** Real-time fill detection during the rest period is unnecessary for v1 — we reconcile once at cancel and that's sufficient for sizing, PnL, and settle. A WS fill feed is a richer-telemetry follow-up if/when we want per-partial diagnostics live.
+- **Does not migrate scripts/probe code.** All one-off probes referenced in the FAK era remain FAK-shaped. The new post-only path gets a single throwaway probe (Step 7 of the implementation plan) that does not get committed.
+
+## Go / no-go criterion for the human
+
+**GO if all of the following hold:**
+
+1. The maker-side hypothesis is the right structural fix — i.e., you believe the live-vs-paper gap is liquidity racing (per the diagnostic memo), not a deeper model bug, and providing liquidity rather than taking it should narrow the gap.
+2. You're comfortable shipping a feature whose first phase of validation is structural (paper + dry-run probe), with the *economic* validation requiring real money on the line at $5/trade.
+3. You're comfortable with the v1 simplicity tradeoffs explicitly listed in §"What this deliberately does NOT do" — particularly single-shot-rest with no repost on book-moves and no signal-staleness re-evaluation.
+4. The four new config constants and their `tests/conftest.py::_key` additions feel like the right surface area (vs. starting with fewer knobs and adding later).
+5. The Protocol extension to `LiveOrderClient` (one new method, one new dataclass) is acceptable in scope. This is the bot's first multi-state order lifecycle and the Protocol is the seam test against.
+
+**NO-GO triggers (push back and revise this design):**
+
+- You want a real-time post-only path in paper mode (not just the replay script). Revise: that's an additional execution-path with its own lifecycle, comparable scope to the live-side work.
+- You want to ship cancel-and-repost on book-moves in v1 (revise: that's roughly +3 tasks and +2 failure modes worth of plan).
+- You want to retire the cushion in the same PR (revise: bundle gate-selectivity change separately; the cushion-retirement question is a v1-validation-output question).
+- You want a different rest offset as the default (e.g. `pmc − 1` for max edge, or `pmc − 5` for adverse-selection safety) — revise the default, keep the offset knob.
+- You see a failure mode in §"What can break" we haven't accounted for — surface it, we re-design.
+
+**Decision required:** GO / NO-GO. If GO, the companion `…-implementation.md` will be drafted as a linear ~8-task plan covering Protocol extension, SDK wrapper, executor lifecycle with place-time pmc recompute, bot.py dispatch, config plumbing including `conftest.py::_key`, the replay script, and the test plan (focused unit per Protocol method + an integration test for the partial-fill + cancel race).

--- a/docs/plans/2026-05-15-post-only-entries-implementation.md
+++ b/docs/plans/2026-05-15-post-only-entries-implementation.md
@@ -1,0 +1,935 @@
+# Post-only / maker-side entries — implementation
+
+Companion to `2026-05-15-post-only-entries-design.md`. Linear, in-chat
+execution — each step is a single concrete action with explicit
+acceptance criteria. No subagent dispatch.
+
+## Pre-flight
+
+- Design doc reviewed and approved.
+- Bot is stopped before any live-touching steps (Steps 7–10).
+- Worktree clean OR carrying only the known pre-existing edits enumerated
+  in the previous v2-migration plan (those don't conflict).
+
+Branch:
+
+```powershell
+git checkout -b feat/post-only-entries
+```
+
+## Step 1 — Config plumbing + conftest._key
+
+In `polypocket/config.py`, append after the existing `IOC_BUFFER_TICKS`
+block:
+
+```python
+# --- Post-only entry path (#TBD post-only-entries) ---
+# Execution mode for live trades. "fak" keeps the current pair-merge taker
+# (FAK-via-v2 SDK) path; "post_only" routes through a GTC + post_only
+# resting maker order. Paper mode ignores this — paper continues to fill
+# at ask instantly. Read at the bot dispatch site, not in the executor.
+ENTRY_MODE = os.getenv("ENTRY_MODE", "fak").strip().lower()
+# Ticks below the pair-merge clearing price (1 - best_opp_bid) to rest a
+# post-only maker order. Default 2: absorbs typical 200–500 ms book drift
+# between gate-eval and SDK sign while still capturing ~7 ticks of edge
+# over the FAK regime's `pmc + IOC_BUFFER_TICKS`. Tune from cohort data
+# after the first 50–100 fills.
+POST_ONLY_REST_OFFSET_TICKS = int(os.getenv("POST_ONLY_REST_OFFSET_TICKS", "2"))
+# Wall-clock seconds-remaining at which the bot tick cancels a resting
+# post-only order. Matches WINDOW_ENTRY_MIN_REMAINING so a post-only fill
+# never lands in the dead-band where the gate also refuses new signals.
+POST_ONLY_CANCEL_AT_T_REMAINING_S = float(os.getenv("POST_ONLY_CANCEL_AT_T_REMAINING_S", "30"))
+# Seconds subtracted from window.end_time when computing the server-side
+# `expiration` field. Defense-in-depth against a bot tick that doesn't fire
+# its own cancel by POST_ONLY_CANCEL_AT_T_REMAINING_S — server kills the
+# order if the bot is silent.
+POST_ONLY_EXPIRY_SAFETY_BUFFER_S = float(os.getenv("POST_ONLY_EXPIRY_SAFETY_BUFFER_S", "30"))
+```
+
+Add the four names to `snapshot_gate_config()`'s returned dict (alphabetic
+or grouped with the existing post-only-adjacent keys; either is fine).
+
+In `tests/conftest.py`, append to the `_key` tuple:
+
+```python
+    "ENTRY_MODE",
+    "POST_ONLY_REST_OFFSET_TICKS",
+    "POST_ONLY_CANCEL_AT_T_REMAINING_S",
+    "POST_ONLY_EXPIRY_SAFETY_BUFFER_S",
+```
+
+**Acceptance:**
+
+- `python -c "from polypocket.config import ENTRY_MODE, POST_ONLY_REST_OFFSET_TICKS, POST_ONLY_CANCEL_AT_T_REMAINING_S, POST_ONLY_EXPIRY_SAFETY_BUFFER_S; print(ENTRY_MODE, POST_ONLY_REST_OFFSET_TICKS)"` prints `fak 2`.
+- `pytest tests/test_config.py` green (the test that asserts `snapshot_gate_config()` round-trips known keys picks up the new ones with no manual edit; if it fails, the test itself needs the new keys added — that's an in-this-PR edit).
+
+## Step 2 — Ledger schema additions
+
+In `polypocket/ledger.py`, inside the `init_db` idempotent ALTER block,
+append:
+
+```python
+if "entry_mode" not in existing_cols:
+    conn.execute("ALTER TABLE trades ADD COLUMN entry_mode TEXT")
+if "rest_price" not in existing_cols:
+    conn.execute("ALTER TABLE trades ADD COLUMN rest_price REAL")
+```
+
+In `log_trade`'s signature, add:
+
+```python
+entry_mode: str | None = None,
+rest_price: float | None = None,
+```
+
+and append both to the INSERT column list / values tuple. Existing
+callers (paper, FAK live) continue to work with the defaults.
+
+**Acceptance:**
+
+- `pytest tests/test_ledger.py` green.
+- One new test in `test_ledger.py`: `test_log_trade_persists_entry_mode_and_rest_price` — call `log_trade(..., entry_mode="post_only", rest_price=0.54)` against an in-memory DB, fetch the row, assert both fields land.
+- Re-running `init_db` against an existing DB does not error and does not duplicate columns (PRAGMA check). Reuse the existing idempotency tests' pattern.
+
+## Step 3 — Pure helper: `post_only_rest_price`
+
+In `polypocket/clients/polymarket.py`, immediately after `ioc_limit_price`,
+add a pure module-level function:
+
+```python
+def post_only_rest_price(
+    side: str,
+    up_bids: list[dict] | None,
+    down_bids: list[dict] | None,
+    offset_ticks: int,
+) -> float | None:
+    """Maker rest price for a BUY UP/DOWN on a binary book.
+
+    Sits `offset_ticks` below the pair-merge clearing price
+    `pmc = 1 - best_opp_bid`. Returns None when the opposite book has no
+    bid (no pair-merge counterparty exists; caller should skip with
+    'no-pair-merge-counterparty'). Floored at $0.01 — a rest at $0.00
+    is meaningless. Capped at $0.99 to mirror the FAK limit convention,
+    though pmc-offset_ticks should never approach $0.99 in practice.
+
+    Conservatively: a non-positive offset_ticks would request a rest at-or-
+    above the cross, which post-only would reject. Caller's responsibility
+    to keep offset_ticks >= 1; this function trusts the input.
+    """
+    opp_bids = down_bids if side == "up" else up_bids
+    if not opp_bids:
+        return None
+    best_opp = max(float(b["price"]) for b in opp_bids)
+    rest = (1.0 - best_opp) - offset_ticks * 0.01
+    return round(max(0.01, min(0.99, rest)), 2)
+```
+
+**Acceptance:**
+
+- New tests in `test_polymarket_client.py` mirroring the `test_ioc_limit_price_*` block:
+  - `test_post_only_rest_price_up_uses_down_bid` — given down_bids [{price:0.45}], offset=2, returns 0.53.
+  - `test_post_only_rest_price_down_uses_up_bid` — symmetric on the other side.
+  - `test_post_only_rest_price_no_opp_bid_returns_none` — empty list returns None.
+  - `test_post_only_rest_price_clamps_to_one_cent_floor` — extreme opp_bid (e.g. 0.99 with offset=5) doesn't return a sub-cent value.
+- Pure function: covered by unit tests only. No mocks needed.
+
+## Step 4 — Protocol extension + `PlaceResult`
+
+In `polypocket/executor.py`:
+
+Add the `PlaceResult` dataclass next to `FillResult`:
+
+```python
+@dataclass(frozen=True)
+class PlaceResult:
+    """Outcome of a post-only place request. Distinct from FillResult,
+    which represents terminal fills; a PlaceResult represents the order's
+    acceptance into the book (or its rejection)."""
+    status: Literal["placed", "rejected", "error"]
+    order_id: str | None
+    error: str | None
+```
+
+Extend `LiveOrderClient` Protocol with:
+
+```python
+def submit_post_only(
+    self, side: str, size: float, price: float,
+    token_id: str, condition_id: str,
+    expiration: int,
+) -> PlaceResult: ...
+```
+
+`expiration` is required (not Optional) at the Protocol level — the
+caller always knows the window deadline, and forcing it shifts the
+default-handling burden off the SDK wrapper.
+
+**Acceptance:**
+
+- `pytest tests/test_executor.py` green — no new tests yet (those land in Step 6 when the executor function uses it).
+- One typing-driven check: any existing stub of `LiveOrderClient` in tests that doesn't implement `submit_post_only` should fail an `isinstance(..., LiveOrderClient)`-style check at test-collection time. Since the existing stubs are duck-typed (Protocol is structural), this won't auto-fail — but a `mypy` or `ruff` sweep would catch missing methods. Skip explicit isinstance assertions; rely on the per-test `MagicMock(spec=LiveOrderClient)` pattern in `test_bot.py` to surface gaps.
+
+## Step 5 — SDK wrapper: `submit_post_only` on `PolymarketClient`
+
+In `polypocket/clients/polymarket.py`:
+
+Add a new error classifier (sibling to `_classify_no_match_error`):
+
+```python
+def _classify_post_only_cross_error(exc: Exception) -> tuple[str, str] | None:
+    """If `exc` is a v2-server post-only-would-cross rejection, return
+    (order_id, label). Verified shape from Phase-3 dry-run probe; until
+    then, accept any 400 with 'post' and 'only' tokens in the message.
+
+    Returns ("post-only-would-cross", order_id_or_empty) on match.
+    """
+    if not isinstance(exc, PolyApiException) or exc.status_code != 400:
+        return None
+    body = exc.error_msg
+    if not isinstance(body, dict):
+        return None
+    err = (body.get("error") or "").lower()
+    if "post" not in err or ("only" not in err and "cross" not in err):
+        return None
+    order_id = body.get("orderID") or ""
+    return order_id, "post-only-would-cross"
+```
+
+Add the import line: `OrderArgs` (alias of `OrderArgsV2`):
+
+```python
+from py_clob_client_v2 import (
+    ApiCreds,
+    AssetType,
+    BalanceAllowanceParams,
+    ClobClient,
+    MarketOrderArgs,
+    OrderArgs,
+    OrderPayload,
+    OrderType,
+    PartialCreateOrderOptions,
+    Side,
+    SignatureTypeV2,
+    TradeParams,
+)
+```
+
+Add the `submit_post_only` method on `PolymarketClient`:
+
+```python
+def submit_post_only(
+    self, side, size, price, token_id, condition_id, expiration,
+):
+    """Post a GTC limit at `price` with post_only=True.
+
+    `size` is in shares (NOT USDC) — this differs from `submit_ioc`/
+    `submit_fok` whose `amount` field is USDC budget. `expiration` is a
+    Unix-seconds timestamp; the server kills the order at that time if
+    it hasn't filled.
+
+    Returns PlaceResult with status="placed" on accepted, "rejected" on
+    server-side rejection (e.g. post-only-would-cross), or "error" on
+    network/signing failure.
+    """
+    if self._dry_run:
+        log.info(
+            "DRY-RUN submit_post_only side=%s size=%.2f price=%.4f exp=%d token=%s cond=%s",
+            side, size, price, expiration, token_id, condition_id,
+        )
+        return PlaceResult(status="placed", order_id="DRY-RUN", error=None)
+
+    # Tick-safe quantization — same defense-in-depth as submit_ioc, kept
+    # for consistency. _tick_safe_size operates on (size, price).
+    target_size_int = max(1, int(round(size)))
+    size_int = _tick_safe_size(target_size_int, price)
+    if size_int is None:
+        log.error(
+            "submit_post_only: no tick-safe size near %d for price=%.4f",
+            target_size_int, price,
+        )
+        return PlaceResult(
+            status="rejected", order_id=None, error="tick-size-unfixable",
+        )
+
+    args = OrderArgs(
+        token_id=token_id,
+        price=price,
+        size=float(size_int),
+        side=Side.BUY,  # mirrors the FAK path's `MarketOrderArgs(side=Side.BUY)`
+                        # — OrderArgsV2.side is annotated `str` but the SDK
+                        # accepts the IntEnum directly (no validation at the
+                        # dataclass layer). str(Side.BUY) would produce
+                        # "Side.BUY" and fail at the order builder.
+        expiration=int(expiration),
+    )
+    try:
+        resp = self._client.create_and_post_order(
+            order_args=args,
+            options=PartialCreateOrderOptions(tick_size=TICK_SIZE),
+            order_type=OrderType.GTC,
+            post_only=True,
+        )
+    except Exception as exc:
+        cross = _classify_post_only_cross_error(exc)
+        if cross is not None:
+            order_id, label = cross
+            return PlaceResult(
+                status="rejected", order_id=order_id or None, error=label,
+            )
+        log.exception("submit_post_only network/signing error")
+        return PlaceResult(
+            status="error", order_id=None, error=f"network: {exc}",
+        )
+
+    # v2 success response: {"success": True, "orderID": "...",
+    #   "status": "live" (resting), "makingAmount": ..., "takingAmount": ...}
+    # A rest order shouldn't have any tradeIDs or matched amounts at place.
+    if not resp.get("success"):
+        err = resp.get("errorMsg") or f"status={resp.get('status')!r}"
+        # Server-level post-only-cross can also arrive as success=False
+        # with errorMsg text (not always as a 400 PolyApiException). Pattern-
+        # match the error text the same way _classify does.
+        lower = err.lower() if isinstance(err, str) else ""
+        if "post" in lower and ("only" in lower or "cross" in lower):
+            return PlaceResult(
+                status="rejected", order_id=resp.get("orderID") or None,
+                error="post-only-would-cross",
+            )
+        return PlaceResult(
+            status="rejected", order_id=resp.get("orderID") or None, error=err,
+        )
+
+    order_id = resp.get("orderID")
+    if not order_id:
+        return PlaceResult(
+            status="rejected", order_id=None, error="no-order-id",
+        )
+
+    return PlaceResult(status="placed", order_id=order_id, error=None)
+```
+
+**Acceptance:**
+
+- New tests in `test_polymarket_client.py`:
+  - `test_submit_post_only_placed` — happy path. Mock `create_and_post_order` to return `{"success": True, "orderID": "abc", "status": "live"}`; assert returned `PlaceResult(status="placed", order_id="abc", error=None)`.
+  - `test_submit_post_only_passes_v2_order_args` — call args check. Mirror the FAK test: assert `OrderArgs` with the right token_id, price, size, **`side == Side.BUY` (the enum value, not the string "Side.BUY" — guards against `str(Side.BUY)` regression)**, expiration; assert `order_type=OrderType.GTC` and `post_only=True` are passed; assert `tick_size="0.01"`.
+  - `test_submit_post_only_would_cross_via_400` — mock `create_and_post_order` to raise a `PolyApiException` with status=400 and a body containing "post-only would cross"; assert `PlaceResult(status="rejected", error="post-only-would-cross")`.
+  - `test_submit_post_only_would_cross_via_success_false` — same outcome via `{"success": False, "errorMsg": "post_only_would_cross"}`.
+  - `test_submit_post_only_network_error` — raise a generic Exception; assert `status="error"` and error starts with `"network:"`.
+  - `test_submit_post_only_tick_safe_unfixable` — patch `_tick_safe_size` to return None; assert `rejected` with `error="tick-size-unfixable"`.
+
+## Step 6 — Executor lifecycle: `execute_live_trade_post_only`
+
+In `polypocket/executor.py`, add a new function after `execute_live_trade`:
+
+```python
+def execute_live_trade_post_only(
+    db_path: str,
+    signal: Signal,
+    intended_size: float,
+    window_slug: str,
+    token_id: str,
+    condition_id: str,
+    client: LiveOrderClient,
+    *,
+    up_bids: list[dict] | None,
+    down_bids: list[dict] | None,
+    offset_ticks: int,
+    expiration: int,
+    submit_book_age_s_monotonic: float | None = None,
+) -> TradeResult:
+    """Place a post-only resting maker order at pmc - offset_ticks.
+
+    Behavior:
+    - Computes rest_price at call-time against the freshest available
+      bids (the caller passes the gate-time bids; the wrapper passes the
+      same bids on through but a future enhancement may pass fresher
+      ones). Rejects with 'no-pair-merge-counterparty' if no opp bid.
+    - Logs trade row at status='placed' with size=intended_size,
+      entry_price=rest_price (intended values; overwritten at cancel).
+    - Writes `place` and `ack` order_events.
+    - On placement reject (post-only-would-cross), trade row goes to
+      status='rejected' immediately and returns failure.
+    - On successful placement, returns a success TradeResult with the
+      order resting. Cancel + reconcile happens in `cancel_post_only_order`
+      called by the bot tick or reconciler.
+
+    Place-time pmc recompute: rest_price is computed inside this function
+    from the bids passed in. If a future enhancement wants a fresher pmc
+    (e.g., a synchronous `client.get_order_book(opposite_token_id)` call
+    between gate and place), do it here.
+    """
+    existing_trade = find_trade_by_window_slug(db_path, window_slug)
+    if existing_trade is not None:
+        return _window_consumed_result(db_path, window_slug)
+
+    from polypocket.clients.polymarket import post_only_rest_price
+    rest_price = post_only_rest_price(signal.side, up_bids, down_bids, offset_ticks)
+    if rest_price is None:
+        return TradeResult(success=False, error="no-pair-merge-counterparty")
+
+    usdc_needed = rest_price * intended_size
+    if client.get_usdc_balance() < usdc_needed:
+        return TradeResult(success=False, error="insufficient-balance")
+
+    fee_sh = fee_shares(intended_size, rest_price)
+    try:
+        trade_id = log_trade(
+            db_path=db_path,
+            window_slug=window_slug,
+            side=signal.side,
+            entry_price=rest_price,
+            size=intended_size,
+            fees=fee_sh,
+            model_p_up=signal.model_p_up,
+            market_p_up=signal.market_price,
+            edge=signal.edge,
+            outcome=None,
+            pnl=None,
+            status="placed",
+            signal_reference_price=signal.signal_reference_price,
+            signal_reference_source="live",
+            entry_mode="post_only",
+            rest_price=rest_price,
+        )
+    except sqlite3.IntegrityError:
+        consumed = _window_consumed_result(db_path, window_slug)
+        if consumed.trade_id is not None:
+            return consumed
+        raise
+
+    log_order_event(
+        db_path, trade_id, window_slug, "place", time.time(),
+        payload={
+            "side": signal.side,
+            "intended_size": intended_size,
+            "rest_price": rest_price,
+            "offset_ticks": offset_ticks,
+            "expiration": expiration,
+            "signal_reference_price": signal.signal_reference_price,
+            "book_age_s_monotonic": submit_book_age_s_monotonic,
+        },
+    )
+    place = client.submit_post_only(
+        side=signal.side, size=intended_size, price=rest_price,
+        token_id=token_id, condition_id=condition_id, expiration=expiration,
+    )
+    log_order_event(
+        db_path, trade_id, window_slug, "ack", time.time(),
+        payload={"status": place.status, "error": place.error},
+        external_order_id=place.order_id,
+    )
+
+    if place.status == "rejected":
+        update_trade(
+            db_path, trade_id, outcome=None, pnl=None, status="rejected",
+            external_order_id=place.order_id, error=place.error,
+        )
+        log_order_event(
+            db_path, trade_id, window_slug, "reject", time.time(),
+            payload={"error": place.error},
+            external_order_id=place.order_id,
+        )
+        log.warning(
+            "post-only reject: %s %s @%.4f x%.2f: %s",
+            window_slug, signal.side, rest_price, intended_size, place.error,
+        )
+        return TradeResult(success=False, trade_id=trade_id, error=place.error)
+
+    if place.status == "error":
+        update_trade(
+            db_path, trade_id, outcome=None, pnl=None, status="rejected",
+            external_order_id=place.order_id, error=place.error,
+        )
+        return TradeResult(success=False, trade_id=trade_id, error=place.error)
+
+    # status == "placed"
+    update_trade(
+        db_path, trade_id, outcome=None, pnl=None, status="placed",
+        external_order_id=place.order_id,
+    )
+    log.info(
+        "post-only PLACED: %s %s rest=$%.4f x%.2f exp=%d token=%s order=%s",
+        window_slug, signal.side, rest_price, intended_size,
+        expiration, token_id, place.order_id,
+    )
+    return TradeResult(success=True, trade_id=trade_id, pnl=None)
+```
+
+Add a companion `cancel_post_only_order` function:
+
+```python
+def cancel_post_only_order(
+    db_path: str,
+    trade: dict,
+    client: LiveOrderClient,
+    trigger: str,
+) -> str:
+    """Cancel a resting post-only order and reconcile.
+
+    Reads the post-cancel CLOB state via get_settlement_info (authoritative
+    even when cancel races a fill). Updates the trade row:
+    - shares_held > 0: status='open' with size=shares_held,
+      entry_price=cost/shares — continues to settlement at window close.
+    - shares_held == 0: status='rejected' with error='post-only-no-fill'.
+
+    Returns the final local status ('open' or 'rejected'). On client
+    errors (cancel failure or settlement-lookup failure), preserves the
+    'placed' status and writes a diagnostic event — the next reconciler
+    pass will retry.
+    """
+    trade_id = trade["id"]
+    window_slug = trade["window_slug"]
+    order_id = trade.get("external_order_id")
+    if not order_id:
+        log.warning("cancel_post_only_order: no order_id on trade %s", trade_id)
+        return trade.get("status", "placed")
+
+    log_order_event(
+        db_path, trade_id, window_slug, "cancel", time.time(),
+        payload={"trigger": trigger, "phase": "request"},
+        external_order_id=order_id,
+    )
+    cancel_ok = False
+    try:
+        cancel_ok = client.cancel_order(order_id)
+    except Exception as exc:
+        log.warning("cancel_post_only_order: cancel_order raised for %s: %s",
+                    order_id, exc)
+
+    try:
+        info = client.get_settlement_info(order_id)
+    except Exception as exc:
+        log.exception("cancel_post_only_order: get_settlement_info failed for %s: %s",
+                      order_id, exc)
+        log_order_event(
+            db_path, trade_id, window_slug, "cancel", time.time(),
+            payload={"trigger": trigger, "phase": "ack",
+                     "cancel_success": cancel_ok,
+                     "settlement_lookup_error": str(exc)},
+            external_order_id=order_id,
+        )
+        return trade.get("status", "placed")
+
+    log_order_event(
+        db_path, trade_id, window_slug, "cancel", time.time(),
+        payload={
+            "trigger": trigger, "phase": "ack",
+            "cancel_success": cancel_ok,
+            "shares_held": info.shares_held,
+            "cost_usdc": info.cost_usdc,
+        },
+        external_order_id=order_id,
+    )
+
+    if info.shares_held > 0:
+        avg_price = info.cost_usdc / info.shares_held
+        update_trade(
+            db_path, trade_id, outcome=None, pnl=None, status="open",
+            size=info.shares_held, entry_price=avg_price,
+        )
+        # update_trade's error column is COALESCE-preserved; clear any
+        # stale error text from earlier transitions on this row so the
+        # promoted-to-open row reads cleanly on post-mortem. Mirrors the
+        # pattern in reconcile_recovered_trade's stranded-fill branch.
+        with closing(sqlite3.connect(db_path)) as conn:
+            conn.execute(
+                "UPDATE trades SET error = NULL WHERE id = ?", (trade_id,),
+            )
+            conn.commit()
+        # Reuse the existing dust-warn line; threshold is the same.
+        notional = info.shares_held * avg_price
+        if notional < MIN_POSITION_USDC * 0.25:
+            log.warning(
+                "post-only dust-fill %s: %.4f @ $%.4f = $%.4f < floor=$%.4f",
+                window_slug, info.shares_held, avg_price, notional,
+                MIN_POSITION_USDC * 0.25,
+            )
+        log_order_event(
+            db_path, trade_id, window_slug, "fill", time.time(),
+            payload={"filled_size": info.shares_held, "avg_price": avg_price,
+                     "via": "cancel-reconcile"},
+            external_order_id=order_id,
+        )
+        log.info(
+            "post-only FILLED via cancel-reconcile: %s %s %.4f @ $%.4f",
+            window_slug, trade["side"], info.shares_held, avg_price,
+        )
+        return "open"
+
+    update_trade(
+        db_path, trade_id, outcome=None, pnl=None, status="rejected",
+        error="post-only-no-fill",
+    )
+    log_order_event(
+        db_path, trade_id, window_slug, "reject", time.time(),
+        payload={"error": "post-only-no-fill"},
+        external_order_id=order_id,
+    )
+    log.info("post-only NO-FILL: %s order=%s trigger=%s",
+             window_slug, order_id, trigger)
+    return "rejected"
+```
+
+Extend `reconcile_recovered_trade` for CLOB status `"live"`:
+
+In the block that reads `clob_status` from `get_order_status`, after the
+existing `"matched"` and `"canceled / cancelled / unmatched"` branches,
+add:
+
+```python
+if clob_status == "live":
+    # A post-only order from a previous run is still resting. Window
+    # context is gone; cancel-and-reconcile inline.
+    log_order_event(
+        db_path, trade["id"], trade["window_slug"], "reconcile_live", time.time(),
+        payload={"from_status": current_status, "clob_status": clob_status},
+        external_order_id=order_id,
+    )
+    return cancel_post_only_order(db_path, trade, client, trigger="crash-recovery")
+```
+
+**Acceptance:**
+
+- `pytest tests/test_executor.py` green plus new tests:
+  - `test_execute_live_trade_post_only_placed_happy_path` — mock client.submit_post_only to return `PlaceResult(status="placed", order_id="abc")`; assert trade row at status=placed with rest_price persisted; assert `place` and `ack` events written.
+  - `test_execute_live_trade_post_only_no_opp_bid_skips` — pass empty down_bids on a BUY UP; assert `TradeResult(success=False, error="no-pair-merge-counterparty")` and no trade row written.
+  - `test_execute_live_trade_post_only_insufficient_balance` — mock get_usdc_balance below need; assert `insufficient-balance` and no trade row.
+  - `test_execute_live_trade_post_only_would_cross_rejected` — mock submit_post_only to return `PlaceResult(status="rejected", error="post-only-would-cross")`; assert trade row at status=rejected with the error persisted; assert `place`, `ack`, `reject` events written.
+  - `test_cancel_post_only_order_full_fill` — mock get_settlement_info to return shares_held=10, cost_usdc=5.40; assert trade promoted to status=open with size=10, entry_price=0.54; assert `cancel` and `fill` events written.
+  - `test_cancel_post_only_order_zero_fill` — mock get_settlement_info shares_held=0; assert status=rejected with error="post-only-no-fill".
+  - `test_cancel_post_only_order_cancel_race_partial_fill` — **integration-style**: mock cancel_order returns False (race), get_settlement_info returns shares_held=4, cost_usdc=2.16; assert trade ends at status=open size=4 entry_price=0.54. This is the load-bearing test for the cancel-race failure mode.
+  - `test_reconcile_recovered_trade_live_status_triggers_cancel` — recovered trade at status=placed with order_id; mock get_order_status returns `{"status": "live"}`; assert cancel_post_only_order is called (verifying the new branch).
+
+## Step 7 — Bot dispatch + cancel-on-tick
+
+In `polypocket/bot.py`:
+
+Add `ENTRY_MODE`, `POST_ONLY_REST_OFFSET_TICKS`, `POST_ONLY_CANCEL_AT_T_REMAINING_S`, `POST_ONLY_EXPIRY_SAFETY_BUFFER_S` to the top-of-file `from polypocket.config import ...` block.
+
+Import the new executor function:
+
+```python
+from polypocket.executor import (
+    LiveOrderClient,
+    TradeResult,
+    cancel_post_only_order,
+    execute_live_trade,
+    execute_live_trade_post_only,
+    ...
+)
+```
+
+In `Bot._on_book_update`, **before** the existing `recoverable_statuses = {"open"}` block, add `"placed"` to the live-mode set so a resting order survives restart:
+
+```python
+recoverable_statuses = {"open"}
+if TRADING_MODE == "live":
+    recoverable_statuses.add("reserved")
+    recoverable_statuses.add("rejected")
+    recoverable_statuses.add("placed")  # post-only resting orders
+```
+
+Add a cancel-on-tick check. Inside `_on_book_update`, after the existing
+"if current window has expired and we're still holding an open trade,
+settle it now" block and before the "Live-only stats/signal evaluation"
+block, add:
+
+```python
+# Post-only cancel-on-tick: if we're holding a resting maker order and the
+# window is in its no-trade band, cancel-and-reconcile so the order doesn't
+# fill into the dead-zone. Server expiration is the safety net; this is the
+# fast-path.
+if (
+    TRADING_MODE != "paper"
+    and self._open_trade is not None
+    and self._open_trade.get("status") == "placed"
+    and self._current_window is not None
+    and (self._current_window.end_time - now) <= POST_ONLY_CANCEL_AT_T_REMAINING_S
+    and self.live_order_client is not None
+):
+    trade_row = find_trade_by_window_slug(self.db_path, self._current_window.slug)
+    if trade_row is not None:
+        final = cancel_post_only_order(
+            self.db_path, trade_row, self.live_order_client,
+            trigger="window-close",
+        )
+        if final == "open":
+            # Reconcile produced a partial fill — adopt it for settlement.
+            updated = find_trade_by_window_slug(self.db_path, self._current_window.slug)
+            self._open_trade = {
+                "trade_id": updated["id"],
+                "side": updated["side"],
+                "entry_price": updated["entry_price"],
+                "size": updated["size"],
+                "mode": TRADING_MODE,
+                "status": "open",
+                "external_order_id": updated.get("external_order_id"),
+            }
+            self.stats["position"] = self._format_position(self._open_trade)
+        else:
+            # rejected — no fill. Drop the open_trade tracking.
+            self._open_trade = None
+            self.stats["position"] = None
+            self.stats["execution_status"] = "post-only-no-fill"
+```
+
+In the live-execution dispatch (the `else:` branch that today calls
+`execute_live_trade(...)`), branch on `ENTRY_MODE`:
+
+```python
+if ENTRY_MODE == "post_only":
+    # Note on settle interaction: if the bot is silent (no book events)
+    # between t_remaining=POST_ONLY_CANCEL_AT_T_REMAINING_S and window
+    # end, the bot-side cancel never fires. The server-side `expiration`
+    # below is the safety net — it kills the order at
+    # window.end_time - POST_ONLY_EXPIRY_SAFETY_BUFFER_S. By _settle_trade
+    # time, get_settlement_info returns shares_held=0 and PnL settles
+    # to 0. A status='placed' row reaching settle is therefore not a
+    # bug — it's the bot-silent path with the safety net engaged.
+    expiration = int(window.end_time - POST_ONLY_EXPIRY_SAFETY_BUFFER_S)
+    result = execute_live_trade_post_only(
+        db_path=self.db_path,
+        signal=signal,
+        intended_size=size,
+        window_slug=window.slug,
+        token_id=token_id,
+        condition_id=window.condition_id,
+        client=self.live_order_client,
+        up_bids=window.up_bids,
+        down_bids=window.down_bids,
+        offset_ticks=POST_ONLY_REST_OFFSET_TICKS,
+        expiration=expiration,
+        submit_book_age_s_monotonic=book_age,
+    )
+else:
+    # existing FAK path
+    result = execute_live_trade(
+        db_path=self.db_path,
+        signal=signal,
+        ...,
+    )
+```
+
+After the existing `if result.success:` block, in the post-only path the
+trade is at `status='placed'` not `'open'` — so the `self._open_trade`
+dict's `status` field must reflect that. Update the existing block to
+read `recorded["status"]` instead of hardcoding `"open"`:
+
+```python
+if result.success:
+    self._window_traded = True
+    ...
+    recorded = find_trade_by_window_slug(self.db_path, window.slug)
+    self._open_trade = {
+        "trade_id": result.trade_id,
+        "side": signal.side,
+        "entry_price": (recorded.get("entry_price") if recorded else entry_price),
+        "size": (recorded.get("size") if recorded else size),
+        "mode": TRADING_MODE,
+        "status": (recorded.get("status") if recorded else "open"),
+        "external_order_id": external_order_id,
+    }
+```
+
+**Acceptance:**
+
+- `pytest tests/test_bot.py` green plus new tests:
+  - `test_bot_dispatches_to_post_only_when_entry_mode_set` — set `ENTRY_MODE=post_only` via monkeypatch; assert the live branch calls `execute_live_trade_post_only`, not `execute_live_trade`.
+  - `test_bot_cancels_post_only_at_t_remaining_threshold` — simulate a tick with `_open_trade.status='placed'` and `t_remaining < POST_ONLY_CANCEL_AT_T_REMAINING_S`; assert `cancel_post_only_order` is called once with `trigger="window-close"`.
+  - `test_bot_post_only_cancel_promotes_partial_fill` — cancel_post_only_order mock returns "open"; assert `_open_trade.status="open"` and position string reflects the filled size.
+  - `test_bot_post_only_cancel_zero_fill_drops_open_trade` — cancel returns "rejected"; assert `_open_trade is None` and stats execution_status reflects no-fill.
+  - `test_recoverable_statuses_includes_placed_in_live` — assert that the live-mode recoverable set includes `"placed"` (small structural test).
+
+## Step 8 — Paper-mode bit-identity check
+
+A standalone test asserting nothing in the paper path changed:
+
+`test_paper_path_unchanged_with_post_only_config_set`:
+
+- Configure `ENTRY_MODE=post_only`, `TRADING_MODE=paper`.
+- Fire a signal through a Bot instance with a mock binance feed and
+  Polymarket window. Assert `execute_paper_trade` is called (not anything
+  post-only). Assert no `submit_post_only` call on any client mock.
+
+This is the bit-identity guarantee promised in the design doc. One test.
+
+**Acceptance:**
+
+- `pytest tests/test_bot.py::test_paper_path_unchanged_with_post_only_config_set` green.
+- Existing paper-mode tests (`test_bot.py`) all still pass with the new code.
+
+## Step 9 — Live probe script (uncommitted)
+
+Write `scripts/_probe_post_only.py` (gitignored; mirrors the v2-migration
+plan's Step 7 pattern):
+
+```python
+"""One-shot probe: place a post-only at $0.01 below pmc on a live BTC
+window, verify it lands, cancel it, confirm zero fill. NOT committed."""
+import os, time
+from polypocket.clients.polymarket import PolymarketClient, post_only_rest_price
+from polypocket import config
+
+client = PolymarketClient(
+    host=config.POLYMARKET_HOST, chain_id=config.CHAIN_ID,
+    private_key=os.environ["PRIVATE_KEY"],
+    api_creds={"key": os.environ["CLOB_API_KEY"],
+               "secret": os.environ["CLOB_SECRET"],
+               "passphrase": os.environ["CLOB_PASSPHRASE"]},
+    proxy_address=os.environ["PROXY_ADDRESS"],
+    dry_run=False,
+)
+
+# Manually populate from /events for an active BTC up/down market:
+TOKEN_ID = "..."
+CONDITION_ID = "..."
+DOWN_BIDS = [{"price": 0.45, "size": 100}]  # placeholder; replace with real
+UP_BIDS = []
+
+rest_price = post_only_rest_price("up", UP_BIDS, DOWN_BIDS, offset_ticks=2)
+print("rest_price:", rest_price)
+
+# Expire in 60 seconds.
+expiration = int(time.time()) + 60
+
+place = client.submit_post_only(
+    side="up", size=10.0, price=rest_price,
+    token_id=TOKEN_ID, condition_id=CONDITION_ID,
+    expiration=expiration,
+)
+print("place result:", place)
+if place.status != "placed":
+    raise SystemExit(f"place failed: {place.error}")
+
+# Verify via /order
+status = client.get_order_status(place.order_id)
+print("order status (should show 'live' and rest price):", status)
+
+input("Press enter to cancel.")
+ok = client.cancel_order(place.order_id)
+print("cancel result:", ok)
+
+info = client.get_settlement_info(place.order_id)
+print("post-cancel settlement (should be 0/0):", info)
+```
+
+**Acceptance:**
+
+1. `client.submit_post_only` returns `PlaceResult(status="placed", order_id=<truthy>)`.
+2. `client.get_order_status(order_id)` shows the order resting at the expected price.
+3. After `cancel_order`, `get_settlement_info` returns `shares_held=0.0, cost_usdc=0.0`.
+4. Document the exact server response shape for the success path in a one-line code comment near `submit_post_only` if the v2 docs were ambiguous.
+5. **Expiration units verification:** place an order with `expiration = int(time.time()) + 60`, then do NOT cancel it. Wait. If the server kills it at ~60 seconds wall-clock (verify via `get_order_status` returning `"cancelled"` or similar), units are Unix-seconds as assumed. If it kills earlier (~60 ms) or never kills, units are milliseconds or something else — fix `POST_ONLY_EXPIRY_SAFETY_BUFFER_S` math at the bot.py dispatch site before proceeding to Step 9.
+6. **Bonus probe (separate run):** force a would-cross — place at `pmc + 1` to deliberately cross. Confirm the rejection error shape. Update `_classify_post_only_cross_error` if needed to match the exact text/code.
+
+If any acceptance criterion fails: STOP. Do not flip `ENTRY_MODE=post_only` in live mode.
+
+## Step 10 — Replay script
+
+Write `scripts/replay_post_only_paper.py` (committed) and run it against
+current `paper_trades.db`:
+
+```python
+"""Post-hoc replay: what would the post-only path have filled, given the
+historical paper FAK cohort's decision snapshots and book samples?
+
+Reads from PAPER_DB_PATH (read-only). Emits scripts/_post_only_replay.md.
+"""
+import sqlite3, json
+from contextlib import closing
+from polypocket.config import (
+    PAPER_DB_PATH, POST_ONLY_REST_OFFSET_TICKS,
+    POST_ONLY_CANCEL_AT_T_REMAINING_S,
+)
+from polypocket.clients.polymarket import post_only_rest_price
+
+def replay(db_path: str = PAPER_DB_PATH) -> dict:
+    """For each window with a 'decision' snapshot + non-null bids JSON
+    + trade_fired=1, compute the would-be rest_price and walk forward
+    through window_book_samples to determine fill outcome.
+
+    Returns aggregate stats: n_placed, n_filled, fill_rate,
+    fills_by_offset_bin, calibration_table.
+    """
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        decisions = conn.execute("""
+            SELECT window_slug, preview_side, model_p_up, up_bids_json,
+                   down_bids_json, timestamp
+            FROM window_snapshots
+            WHERE snapshot_type='decision' AND trade_fired=1
+              AND up_bids_json IS NOT NULL AND down_bids_json IS NOT NULL
+        """).fetchall()
+
+        # For each decision, compute rest_price; walk samples to find fill.
+        ...
+        # Join to trades.outcome for the calibration table.
+```
+
+Full implementation (~150 LOC) is left for the engineer to write at task
+time; this plan's scope is to specify the interface and acceptance:
+
+**Acceptance:**
+
+1. `python scripts/replay_post_only_paper.py` exits 0 against a
+   populated `paper_trades.db`.
+2. Emits `scripts/_post_only_replay.md` with at least: total decisions
+   evaluated, fill rate, mean fill timing (sample-index at fill),
+   would-be calibration per `model_p_up` decile.
+3. Fill rate is in the plausible band 15–80%. Outside that band, halt
+   and revisit `POST_ONLY_REST_OFFSET_TICKS`.
+4. Re-running the script is idempotent — no DB writes, deterministic
+   output for the same input.
+
+## Step 11 — Commit + PR
+
+Conventional Commits with scope, mirroring the v2-migration pattern:
+
+```
+chore(config): add ENTRY_MODE, POST_ONLY_REST_OFFSET_TICKS, *_CANCEL_AT_T_REMAINING_S, *_EXPIRY_SAFETY_BUFFER_S
+chore(ledger): add entry_mode + rest_price columns to trades (idempotent)
+feat(clients): add submit_post_only and post_only_rest_price to Polymarket v2 wrapper
+feat(executor): post-only entry lifecycle and cancel-reconcile path
+feat(bot): dispatch on ENTRY_MODE and cancel resting orders at t_remaining ≤ 30s
+chore(scripts): add post-only paper replay
+docs(plans): post-only entries design + implementation
+test: post-only Protocol, executor, bot dispatch, replay
+```
+
+PR title: `feat: post-only / maker-side entry path behind ENTRY_MODE flag`.
+Body references the diagnostic memory and the design doc. Default is
+`ENTRY_MODE=fak`; promotion to `post_only` is a separate, post-validation
+ops change (set the env var in the live process), not a code change.
+
+## Step 12 — Memory updates after live cohort lands
+
+Reserved for after a successful Phase-4 live cohort. Out-of-PR
+follow-up:
+
+- Update `project_live_v2_execution_gap.md` with the Phase-4 result —
+  whether the calibration gap closed under post-only.
+- If post-only wins the cohort, write a new memory
+  `project_post_only_validated.md` noting `ENTRY_MODE=post_only` as the
+  new default and the cohort that drove it.
+
+## Effort estimate
+
+| Step | Time |
+|---|---|
+| 1 — config + conftest | 15 min |
+| 2 — ledger schema | 15 min |
+| 3 — post_only_rest_price helper + tests | 30 min |
+| 4 — Protocol + PlaceResult | 15 min |
+| 5 — submit_post_only + tests | 60–90 min |
+| 6 — executor lifecycle + cancel + recovery + tests | 90–120 min |
+| 7 — bot dispatch + cancel-on-tick + tests | 60 min |
+| 8 — paper bit-identity test | 15 min |
+| 9 — live probe | 30 min |
+| 10 — replay script | 60–90 min |
+| 11 — commit + PR | 20 min |
+
+Total: ~7–9 hours of focused work. The executor lifecycle (Step 6) and
+SDK wrapper (Step 5) are the heaviest; bot dispatch (Step 7) is
+moderate but the cancel-on-tick logic interacts with existing recovery
+flow and warrants care.

--- a/docs/runbooks/post-only-live-cohort.md
+++ b/docs/runbooks/post-only-live-cohort.md
@@ -1,0 +1,197 @@
+# Post-only live cohort — runbook
+
+**Last updated:** 2026-05-16 (after Step-9 probe landed; GTD + 60s expiration
+fixes shipped in `b58fab2`).
+
+This runbook drives the small-cohort live validation of the post-only
+entry path. Target: 50–100 trades at `MIN_POSITION_USDC = $5` to compare
+live-vs-paper calibration on the DOWN side (the structural gap from the
+2026-05-15 v2-execution-seam diagnostic).
+
+The Step-9 probe is already done. This runbook covers the cohort run +
+analysis only.
+
+## Pre-flight
+
+1. **Branch + commits up to date.** `feat/post-only-entries` HEAD should be
+   `b58fab2` or later (GTD + expiration-floor fixes from the live probe).
+2. **`.env` ready:**
+   - `TRADING_MODE=live`
+   - `ENTRY_MODE=post_only`
+   - `MIN_POSITION_USDC=5.0`, `MAX_POSITION_USDC=5.0` (the cohort sizes
+     every trade at the floor — keeps cohort cost bounded at $250–$500
+     of capital churn, most of it ROI-neutral)
+   - All five CLOB env vars set: `PRIVATE_KEY`, `CLOB_API_KEY`,
+     `CLOB_SECRET`, `CLOB_PASSPHRASE`, `PROXY_ADDRESS`
+3. **Funder balance check:**
+   ```powershell
+   python -c "
+   import os; os.environ.setdefault('TRADING_MODE','live')
+   from dotenv import load_dotenv; load_dotenv('.env', override=True)
+   from polypocket import config
+   from polypocket.clients.polymarket import PolymarketClient
+   c = PolymarketClient(host=config.POLYMARKET_HOST, chain_id=config.CHAIN_ID,
+       private_key=os.environ['PRIVATE_KEY'],
+       api_creds={'key': os.environ['CLOB_API_KEY'],
+                  'secret': os.environ['CLOB_SECRET'],
+                  'passphrase': os.environ['CLOB_PASSPHRASE']},
+       proxy_address=os.environ['PROXY_ADDRESS'], dry_run=False)
+   print('pUSD balance:', c.get_usdc_balance())
+   "
+   ```
+   Need at minimum `2 * MIN_POSITION_USDC` (~$10) for two concurrent trades.
+   For the full cohort budget on ~$5/trade and possibly stranded shares,
+   $30+ is comfortable.
+4. **Existing `live_trades.db`:** the cohort writes to whatever the bot
+   uses (defaults to `live_trades.db` in the repo root via
+   `LIVE_DB_PATH`). If you want a clean cohort DB, set `--db
+   live_trades_post_only_cohort.db` on the start command.
+
+## Start the bot
+
+From a terminal you can leave open for hours (NOT inside Claude's session
+— the agent's background tasks don't persist across sessions):
+
+```powershell
+python -m polypocket run
+```
+
+Or with a cohort-specific DB:
+
+```powershell
+python -m polypocket run --db live_trades_post_only_cohort.db
+```
+
+Tail the log to confirm the first place lands cleanly:
+
+- Look for `post-only PLACED: btc-updown-5m-... up rest=$0.5X x5.0 exp=...`
+  in the bot log — that's the executor confirming a successful place.
+- Confirm `/order` records the order via `_post_only_replay.md`-style
+  inspection (`scripts/replay_post_only_paper.py`-equivalent for live is
+  a follow-up — for now, eyeball the `order_events` table for the
+  first few trades).
+
+If the first place returns `error='post-only-would-cross'` repeatedly,
+the offset is too aggressive — stop the bot and bump
+`POST_ONLY_REST_OFFSET_TICKS` from the default 2 → 3 in `.env` and
+restart.
+
+## Halt / stop the cohort
+
+Two mechanisms:
+
+**A. Kill file (graceful):**
+```powershell
+New-Item -ItemType File .cohort_stop -Force | Out-Null
+```
+The bot's `_on_book_update` checks `cohort_stop_requested()` at the top
+and returns early. New trades stop; in-flight 'placed' orders continue
+on their normal cancel-on-tick / window-end / server-expiration path.
+
+**B. Ctrl-C (signal):** in the terminal running the bot. The bot's
+`asyncio.CancelledError` handler runs cleanup; any 'placed' rows are
+left to the next startup's `find_unsettled_trades` + cancel-reconcile
+path (shipped in `000bf15`).
+
+Don't forget to remove `.cohort_stop` after the cohort:
+```powershell
+Remove-Item .cohort_stop -ErrorAction SilentlyContinue
+```
+
+## Per-trade halt criteria
+
+Stop the cohort early if any of:
+
+- **Server consistently rejects placement.** Three consecutive
+  `error='post-only-would-cross'` rejects in adjacent windows suggests
+  the offset is misaligned with current book dynamics.
+- **Server returns an error shape `_classify_post_only_cross_error`
+  does not recognize.** Surface as a network: error in the trade row —
+  investigate before continuing.
+- **Cancel-race partial fill drift.** If multiple trades land with
+  `entry_mode='post_only'` but `size` much smaller than intended (dust
+  fills via the cancel-reconcile path), the offset may be too
+  aggressive — consider raising it.
+- **PnL drift exceeds the existing cohort guard** (`MAX_DAILY_LOSS = $15`
+  per `polypocket/config.py`). The bot self-halts.
+
+## Mid-cohort progress check
+
+While the bot runs, inspect progress without disturbing it:
+
+```powershell
+python -c "
+import sqlite3
+db = 'live_trades.db'  # or your --db override
+with sqlite3.connect(db) as c:
+    c.row_factory = sqlite3.Row
+    rows = c.execute(
+        \"SELECT status, entry_mode, COUNT(*) n FROM trades GROUP BY status, entry_mode\"
+    ).fetchall()
+    for r in rows: print(dict(r))
+"
+```
+
+Look for: `entry_mode='post_only'` rows with `status` in
+`{placed, open, settled, rejected}`.
+
+**Fill rate sanity check** mid-cohort:
+- `placed → settled` (via open) = fills.
+- `placed → rejected` with `error='post-only-no-fill'` = the resting
+  order timed out without a counterparty crossing.
+- Post-hoc paper replay (`scripts/_post_only_replay.md`) reported 28.9%
+  fill rate at offset=2 — live should land at-or-above that since live
+  observes intra-30s fills the replay misses.
+
+## Cohort analysis (after halt)
+
+Once n=50–100 has accumulated:
+
+```powershell
+python -m polypocket.scripts.model_health  # or equivalent
+# (live calibration split by entry_mode is a planned follow-up; for
+# now, the cohort_id can be derived from window_slug timestamp +
+# trade.entry_mode='post_only')
+```
+
+The key questions for the GO/NO-GO decision on flipping `ENTRY_MODE`
+default:
+
+1. **DOWN-side calibration gap closure.** Diagnostic showed live FAK
+   was -11.7pt UNDER paper on DOWN. Did post-only close to within ±3pt?
+2. **Fill rate vs replay.** Live should be at-or-above the
+   28.9% replay number. A live rate materially *below* the replay
+   means our presence on the book changes other actors' behavior.
+3. **Realized entry vs rest_price.** Should be approximately zero
+   (`entry_price ≈ rest_price` since post-only fills only at rest).
+4. **No adverse-selection blowup.** Pre-flight expectation is some
+   adverse selection (the design's chief acknowledged trade-off). If
+   the cohort PnL is materially worse than the FAK cohort at the same
+   model+gate config, that's a flag for the v2 enhancement
+   (cancel-and-repost on book-moves).
+
+## Rollback
+
+If the cohort surfaces a blocker (any halt criterion above, or the
+final analysis fails GO):
+
+1. Set `ENTRY_MODE=fak` back in `.env`.
+2. Restart the bot — FAK path is bit-identical to pre-PR (guarded by
+   `test_paper_path_unchanged_with_post_only_config_set`).
+3. Open a follow-up issue with the cohort findings + decision-quality
+   data attached.
+
+## Server-side constraints to remember
+
+From the Step-9 probe on 2026-05-16:
+
+- **`expiration` units are Unix seconds**, NOT milliseconds.
+- **`expiration` minimum is `now + 60s`.** The bot floors via
+  `POLYMARKET_MIN_EXPIRATION_BUFFER_S = 65`.
+- **`OrderType.GTC` + non-zero `expiration` is rejected.** Use
+  `OrderType.GTD` when expiration > 0 — `submit_post_only` handles
+  this automatically.
+- **Post-only-would-cross error shape:** HTTP 400 with
+  `{"error": "invalid post-only order: order crosses book"}`.
+- **/order status field is uppercase:** `LIVE`, `MATCHED`, `CANCELED`.
+  The reconciler lowercases via `.strip().lower()` before matching.

--- a/polypocket/bot.py
+++ b/polypocket/bot.py
@@ -12,12 +12,16 @@ from polypocket.config import (
     DEPTH_CLAMP_BUFFER,
     EDGE_FLOOR,
     EDGE_RANGE,
+    ENTRY_MODE,
     IOC_BUFFER_TICKS,
     MAX_BOOK_AGE_S,
     MAX_POSITION_USDC,
     MIN_FILL_RATIO,
     MIN_POSITION_USDC,
     PAPER_DB_PATH,
+    POST_ONLY_CANCEL_AT_T_REMAINING_S,
+    POST_ONLY_EXPIRY_SAFETY_BUFFER_S,
+    POST_ONLY_REST_OFFSET_TICKS,
     TRADING_MODE,
     VOL_FLOOR,
     VOL_RANGE,
@@ -29,7 +33,9 @@ from polypocket.clients.polymarket import ioc_limit_price
 from polypocket.executor import (
     LiveOrderClient,
     TradeResult,
+    cancel_post_only_order,
     execute_live_trade,
+    execute_live_trade_post_only,
     execute_paper_trade,
     reconcile_recovered_trade,
     settle_live_trade,
@@ -134,6 +140,8 @@ class Bot:
         position = f'{trade["size"]:.1f} {trade["side"].upper()} @ ${trade["entry_price"]:.3f}'
         if trade.get("mode") == "live" and trade.get("status") == "reserved":
             return f"{position} (reserved)"
+        if trade.get("mode") == "live" and trade.get("status") == "placed":
+            return f"{position} (resting)"
         return position
 
     async def _on_book_update(self, window: Window, side: str) -> None:
@@ -233,8 +241,11 @@ class Bot:
                 # covers the stranded-fill sweep — the reconciler checks if
                 # anything actually matched on-chain for rejected rows that
                 # still carry an external_order_id, and promotes them.
+                # 'placed' covers a post-only resting order that survived a
+                # restart — the reconciler cancels it inline.
                 recoverable_statuses.add("reserved")
                 recoverable_statuses.add("rejected")
+                recoverable_statuses.add("placed")
             if recovered_trade is not None and recovered_trade["status"] in recoverable_statuses:
                 final_status = recovered_trade["status"]
                 if TRADING_MODE == "live" and recovered_trade.get("external_order_id"):
@@ -321,6 +332,44 @@ class Bot:
                 )
                 if self.on_stats_update:
                     self.on_stats_update(self.stats)
+
+        # Post-only cancel-on-tick: if a resting maker order is approaching
+        # the no-trade band at window-end, cancel-and-reconcile so the order
+        # doesn't fill into the dead-zone. Server-side `expiration` is the
+        # safety net; this fast-path runs as soon as the bot sees a book
+        # event within the threshold.
+        if (
+            TRADING_MODE != "paper"
+            and self._open_trade is not None
+            and self._open_trade.get("status") == "placed"
+            and self._current_window is not None
+            and (self._current_window.end_time - now) <= POST_ONLY_CANCEL_AT_T_REMAINING_S
+            and self.live_order_client is not None
+        ):
+            trade_row = find_trade_by_window_slug(self.db_path, self._current_window.slug)
+            if trade_row is not None and trade_row.get("status") == "placed":
+                final = cancel_post_only_order(
+                    self.db_path, trade_row, self.live_order_client,
+                    trigger="window-close",
+                )
+                if final == "open":
+                    updated = find_trade_by_window_slug(
+                        self.db_path, self._current_window.slug,
+                    )
+                    self._open_trade = {
+                        "trade_id": updated["id"],
+                        "side": updated["side"],
+                        "entry_price": updated["entry_price"],
+                        "size": updated["size"],
+                        "mode": TRADING_MODE,
+                        "status": "open",
+                        "external_order_id": updated.get("external_order_id"),
+                    }
+                    self.stats["position"] = self._format_position(self._open_trade)
+                else:
+                    self._open_trade = None
+                    self.stats["position"] = None
+                    self.stats["execution_status"] = "post-only-no-fill"
 
         # Live-only: stats updates, signal evaluation, and mid-window
         # snapshot emission apply only when the incoming event is for the
@@ -633,19 +682,44 @@ class Bot:
                 time.monotonic() - window.book_updated_at
                 if window.book_updated_at is not None else None
             )
-            result = execute_live_trade(
-                db_path=self.db_path,
-                signal=signal,
-                entry_price=entry_price,
-                size=size,
-                window_slug=window.slug,
-                token_id=token_id,
-                condition_id=window.condition_id,
-                client=self.live_order_client,
-                limit_price=limit_price,
-                submit_book_age_s_monotonic=book_age,
-                opposite_token_id=opposite_token_id,
-            )
+            if ENTRY_MODE == "post_only":
+                # Server-side `expiration` is the safety net for a silent
+                # bot. If the bot tick never reaches the cancel block above
+                # (no book events between t_remaining=cancel_threshold and
+                # window-end), the server kills the order at this timestamp.
+                # By the time _settle_trade runs at window close,
+                # get_settlement_info returns shares_held=0 and PnL settles
+                # to 0 — a status='placed' row reaching settle is the
+                # bot-silent path with the safety net engaged, not a bug.
+                expiration = int(window.end_time - POST_ONLY_EXPIRY_SAFETY_BUFFER_S)
+                result = execute_live_trade_post_only(
+                    db_path=self.db_path,
+                    signal=signal,
+                    intended_size=size,
+                    window_slug=window.slug,
+                    token_id=token_id,
+                    condition_id=window.condition_id,
+                    client=self.live_order_client,
+                    up_bids=window.up_bids,
+                    down_bids=window.down_bids,
+                    offset_ticks=POST_ONLY_REST_OFFSET_TICKS,
+                    expiration=expiration,
+                    submit_book_age_s_monotonic=book_age,
+                )
+            else:
+                result = execute_live_trade(
+                    db_path=self.db_path,
+                    signal=signal,
+                    entry_price=entry_price,
+                    size=size,
+                    window_slug=window.slug,
+                    token_id=token_id,
+                    condition_id=window.condition_id,
+                    client=self.live_order_client,
+                    limit_price=limit_price,
+                    submit_book_age_s_monotonic=book_age,
+                    opposite_token_id=opposite_token_id,
+                )
 
             # Diagnostic log: compare snapshot vs. realized fill for root-cause analysis.
             recorded = find_trade_by_window_slug(self.db_path, window.slug)
@@ -709,21 +783,30 @@ class Bot:
         if result.success:
             self._window_traded = True
             external_order_id = None
+            # Post-only places the order at status='placed', not 'open' —
+            # read both fields from the recorded row so the in-memory
+            # _open_trade tracks the executor's truth.
+            recorded_status = "open"
+            recorded_entry_price = entry_price
+            recorded_size = size
             if TRADING_MODE != "paper":
                 recorded = find_trade_by_window_slug(self.db_path, window.slug)
                 if recorded is not None:
                     external_order_id = recorded.get("external_order_id")
+                    recorded_status = recorded.get("status", "open")
+                    recorded_entry_price = recorded.get("entry_price", entry_price)
+                    recorded_size = recorded.get("size", size)
             self._open_trade = {
                 "trade_id": result.trade_id,
                 "side": signal.side,
-                "entry_price": entry_price,
-                "size": size,
+                "entry_price": recorded_entry_price,
+                "size": recorded_size,
                 "mode": TRADING_MODE,
-                "status": "open",
+                "status": recorded_status,
                 "external_order_id": external_order_id,
             }
             self.stats["position"] = self._format_position(self._open_trade)
-            self.stats["execution_status"] = "open"
+            self.stats["execution_status"] = recorded_status
             if self.on_trade:
                 self.on_trade(result, signal, window.slug)
             if self.on_stats_update:

--- a/polypocket/bot.py
+++ b/polypocket/bot.py
@@ -301,43 +301,15 @@ class Bot:
                 )
             self._ptb_last_fetch = 0.0
 
-        # If the current window has expired and we're still holding an open
-        # trade, settle it now — regardless of whether this book event is
-        # for the live slot. Pre-subscribed next-slot events frequently
-        # arrive before any post-expiry event for the old slot.
-        if (
-            self._open_trade is not None
-            and self._current_window is not None
-            and self._current_window.end_time <= now
-        ):
-            outcome = await fetch_resolution(self._current_window.slug)
-            if outcome is not None:
-                log.info(
-                    "Official resolution for %s: %s",
-                    self._current_window.slug,
-                    outcome.upper(),
-                )
-                await self._settle_trade(outcome)
-            else:
-                self._pending_settlements.append({
-                    **self._open_trade,
-                    "window_slug": self._current_window.slug,
-                })
-                self._open_trade = None
-                self.stats["position"] = None
-                self.stats["execution_status"] = None
-                log.info(
-                    "Parked trade for expired window %s, awaiting resolution",
-                    self._current_window.slug,
-                )
-                if self.on_stats_update:
-                    self.on_stats_update(self.stats)
-
         # Post-only cancel-on-tick: if a resting maker order is approaching
-        # the no-trade band at window-end, cancel-and-reconcile so the order
-        # doesn't fill into the dead-zone. Server-side `expiration` is the
-        # safety net; this fast-path runs as soon as the bot sees a book
-        # event within the threshold.
+        # (or past) the no-trade band at window-end, cancel-and-reconcile so
+        # the order doesn't get settled blindly. The threshold check fires
+        # whenever (end_time - now) <= POST_ONLY_CANCEL_AT_T_REMAINING_S,
+        # including negative deltas — so a bot that was silent through the
+        # cancel deadline still routes 'placed' through the cancel-reconcile
+        # path here (which queries CLOB authoritatively for shares_held)
+        # before the expired-window settle block below runs. Server-side
+        # `expiration` is the safety net for orders the bot truly never sees.
         if (
             TRADING_MODE != "paper"
             and self._open_trade is not None
@@ -370,6 +342,41 @@ class Bot:
                     self._open_trade = None
                     self.stats["position"] = None
                     self.stats["execution_status"] = "post-only-no-fill"
+
+        # If the current window has expired and we're still holding an open
+        # trade, settle it now — regardless of whether this book event is
+        # for the live slot. Pre-subscribed next-slot events frequently
+        # arrive before any post-expiry event for the old slot. Any 'placed'
+        # trade reaching here has already been routed through the cancel-
+        # reconcile block above, so _open_trade is either 'open' (real
+        # position to settle) or None (no fill).
+        if (
+            self._open_trade is not None
+            and self._current_window is not None
+            and self._current_window.end_time <= now
+        ):
+            outcome = await fetch_resolution(self._current_window.slug)
+            if outcome is not None:
+                log.info(
+                    "Official resolution for %s: %s",
+                    self._current_window.slug,
+                    outcome.upper(),
+                )
+                await self._settle_trade(outcome)
+            else:
+                self._pending_settlements.append({
+                    **self._open_trade,
+                    "window_slug": self._current_window.slug,
+                })
+                self._open_trade = None
+                self.stats["position"] = None
+                self.stats["execution_status"] = None
+                log.info(
+                    "Parked trade for expired window %s, awaiting resolution",
+                    self._current_window.slug,
+                )
+                if self.on_stats_update:
+                    self.on_stats_update(self.stats)
 
         # Live-only: stats updates, signal evaluation, and mid-window
         # snapshot emission apply only when the incoming event is for the
@@ -725,36 +732,58 @@ class Bot:
             recorded = find_trade_by_window_slug(self.db_path, window.slug)
             recorded_status = recorded.get("status") if recorded else None
             recorded_error = recorded.get("error") if recorded else None
-            # For rejected/reserved rows, size & entry_price still hold the
-            # *intended* values (never overwritten by a failed fill). Reporting
-            # them as `filled` and `vwap` would lie — only read them when the
-            # trade actually transitioned to an on-chain fill (open/settled).
+            # For rejected/reserved/placed rows, size & entry_price still hold
+            # the *intended* values (never overwritten by a failed fill).
+            # Reporting them as `filled` and `vwap` would lie — only read them
+            # when the trade actually transitioned to an on-chain fill
+            # (open/settled).
             is_fill = recorded_status in {"open", "settled"}
             actual_size = recorded.get("size") if (recorded and is_fill) else None
             actual_price = recorded.get("entry_price") if (recorded and is_fill) else None
             shortfall = (size - actual_size) if actual_size is not None else None
-            # Capture the opposite-book best bid that drove limit_price, so
-            # post-mortem can compare the decision-time clearing vs. the
-            # realized fill. Matches the opp_bids pick in ioc_limit_price.
+            # Capture the opposite-book best bid so post-mortem can compare
+            # the decision-time clearing vs. the realized fill. Matches the
+            # opp_bids pick in ioc_limit_price / post_only_rest_price.
             opp_bids_for_diag = window.down_bids if signal.side == "up" else window.up_bids
             best_opp_bid = max(
                 (float(b["price"]) for b in (opp_bids_for_diag or [])),
                 default=None,
             )
             implied_clearing = (1.0 - best_opp_bid) if best_opp_bid is not None else None
-            log.info(
-                "IOC_DIAG intended=%.4f target=%.4f fillable=%.4f limit=%.4f "
-                "opp_best_bid=%s implied_clearing=%s "
-                "status=%s error=%s filled=%s vwap=%s shortfall=%s",
-                intended_size_pre_clamp, size, fillable, limit_price,
-                f"{best_opp_bid:.4f}" if best_opp_bid is not None else "n/a",
-                f"{implied_clearing:.4f}" if implied_clearing is not None else "n/a",
-                recorded_status or "n/a",
-                recorded_error or "n/a",
-                f"{actual_size:.4f}" if actual_size is not None else "n/a",
-                f"{actual_price:.4f}" if actual_price is not None else "n/a",
-                f"{shortfall:.4f}" if shortfall is not None else "n/a",
-            )
+            if ENTRY_MODE == "post_only":
+                # Post-only: limit_price (FAK helper output) was computed but
+                # not used. rest_price is the actual placement, lifted from
+                # the trade row so we report the same value the executor
+                # signed against.
+                rest_price = recorded.get("rest_price") if recorded else None
+                log.info(
+                    "POST_ONLY_DIAG intended=%.4f target=%.4f rest_price=%s "
+                    "opp_best_bid=%s implied_clearing=%s "
+                    "status=%s error=%s filled=%s vwap=%s shortfall=%s",
+                    intended_size_pre_clamp, size,
+                    f"{rest_price:.4f}" if rest_price is not None else "n/a",
+                    f"{best_opp_bid:.4f}" if best_opp_bid is not None else "n/a",
+                    f"{implied_clearing:.4f}" if implied_clearing is not None else "n/a",
+                    recorded_status or "n/a",
+                    recorded_error or "n/a",
+                    f"{actual_size:.4f}" if actual_size is not None else "n/a",
+                    f"{actual_price:.4f}" if actual_price is not None else "n/a",
+                    f"{shortfall:.4f}" if shortfall is not None else "n/a",
+                )
+            else:
+                log.info(
+                    "IOC_DIAG intended=%.4f target=%.4f fillable=%.4f limit=%.4f "
+                    "opp_best_bid=%s implied_clearing=%s "
+                    "status=%s error=%s filled=%s vwap=%s shortfall=%s",
+                    intended_size_pre_clamp, size, fillable, limit_price,
+                    f"{best_opp_bid:.4f}" if best_opp_bid is not None else "n/a",
+                    f"{implied_clearing:.4f}" if implied_clearing is not None else "n/a",
+                    recorded_status or "n/a",
+                    recorded_error or "n/a",
+                    f"{actual_size:.4f}" if actual_size is not None else "n/a",
+                    f"{actual_price:.4f}" if actual_price is not None else "n/a",
+                    f"{shortfall:.4f}" if shortfall is not None else "n/a",
+                )
 
         if not result.success and result.error == "window-already-consumed":
             self._window_traded = True
@@ -943,9 +972,31 @@ class Bot:
         init_db(self.db_path)
         log.info("Polypocket bot starting (mode=%s)", TRADING_MODE)
 
-        # Recover unsettled trades from previous runs
+        # Recover unsettled trades from previous runs. 'placed' rows (post-only
+        # rest orders that survived a bot-down-through-window scenario) need
+        # to be cancel-reconciled inline before pending settle — otherwise
+        # settle_live_trade would write 'settled, pnl=0' over a row that may
+        # still have a real partial fill on-chain.
         unsettled = find_unsettled_trades(self.db_path)
+        normalized: list[dict] = []
         for row in unsettled:
+            if (
+                row["status"] == "placed"
+                and TRADING_MODE != "paper"
+                and self.live_order_client is not None
+            ):
+                final = cancel_post_only_order(
+                    self.db_path, row, self.live_order_client,
+                    trigger="startup-recovery",
+                )
+                if final != "open":
+                    continue  # rejected / no-fill — nothing to settle
+                refreshed = find_trade_by_window_slug(self.db_path, row["window_slug"])
+                if refreshed is None or refreshed.get("status") != "open":
+                    continue
+                row = refreshed
+            normalized.append(row)
+        for row in normalized:
             self._pending_settlements.append({
                 "trade_id": row["id"],
                 "side": row["side"],
@@ -957,7 +1008,10 @@ class Bot:
                 "external_order_id": row.get("external_order_id"),
             })
         if unsettled:
-            log.info("Recovered %d unsettled trade(s) from database", len(unsettled))
+            log.info(
+                "Recovered %d unsettled trade(s) from database (%d carried to pending)",
+                len(unsettled), len(normalized),
+            )
 
         async def poll_and_stream():
             while not self.stop.is_set():

--- a/polypocket/bot.py
+++ b/polypocket/bot.py
@@ -19,6 +19,7 @@ from polypocket.config import (
     MIN_FILL_RATIO,
     MIN_POSITION_USDC,
     PAPER_DB_PATH,
+    POLYMARKET_MIN_EXPIRATION_BUFFER_S,
     POST_ONLY_CANCEL_AT_T_REMAINING_S,
     POST_ONLY_EXPIRY_SAFETY_BUFFER_S,
     POST_ONLY_REST_OFFSET_TICKS,
@@ -694,11 +695,17 @@ class Bot:
                 # bot. If the bot tick never reaches the cancel block above
                 # (no book events between t_remaining=cancel_threshold and
                 # window-end), the server kills the order at this timestamp.
-                # By the time _settle_trade runs at window close,
-                # get_settlement_info returns shares_held=0 and PnL settles
-                # to 0 — a status='placed' row reaching settle is the
-                # bot-silent path with the safety net engaged, not a bug.
-                expiration = int(window.end_time - POST_ONLY_EXPIRY_SAFETY_BUFFER_S)
+                #
+                # Floor at `now + POLYMARKET_MIN_EXPIRATION_BUFFER_S` (default
+                # 65s, mirroring the server's 60s security threshold + 5s
+                # safety): the v2 server rejects any expiration value less
+                # than now+60 with HTTP 400 (empirical, Step-9 probe). When
+                # t_remaining is too small for the buffer-from-end target
+                # to clear that floor, the floor wins; the bot-side cancel-
+                # on-tick handles window-end protection in that band.
+                target_exp = int(window.end_time - POST_ONLY_EXPIRY_SAFETY_BUFFER_S)
+                server_min_exp = int(time.time()) + int(POLYMARKET_MIN_EXPIRATION_BUFFER_S)
+                expiration = max(target_exp, server_min_exp)
                 result = execute_live_trade_post_only(
                     db_path=self.db_path,
                     signal=signal,

--- a/polypocket/bot.py
+++ b/polypocket/bot.py
@@ -628,6 +628,7 @@ class Bot:
             if self.live_order_client is None:
                 raise RuntimeError("live_order_client is required for live trading mode")
             token_id = window.up_token_id if signal.side == "up" else window.down_token_id
+            opposite_token_id = window.down_token_id if signal.side == "up" else window.up_token_id
             book_age = (
                 time.monotonic() - window.book_updated_at
                 if window.book_updated_at is not None else None
@@ -643,6 +644,7 @@ class Bot:
                 client=self.live_order_client,
                 limit_price=limit_price,
                 submit_book_age_s_monotonic=book_age,
+                opposite_token_id=opposite_token_id,
             )
 
             # Diagnostic log: compare snapshot vs. realized fill for root-cause analysis.

--- a/polypocket/clients/polymarket.py
+++ b/polypocket/clients/polymarket.py
@@ -10,6 +10,7 @@ from py_clob_client_v2 import (
     BalanceAllowanceParams,
     ClobClient,
     MarketOrderArgs,
+    OrderArgs,
     OrderPayload,
     OrderType,
     PartialCreateOrderOptions,
@@ -20,7 +21,7 @@ from py_clob_client_v2 import (
 from py_clob_client_v2.exceptions import PolyApiException
 
 from polypocket.config import FOK_SLIPPAGE_TICKS
-from polypocket.executor import FillResult, SettlementInfo
+from polypocket.executor import FillResult, PlaceResult, SettlementInfo
 
 log = logging.getLogger(__name__)
 
@@ -66,6 +67,29 @@ def _classify_no_match_error(exc: Exception) -> tuple[str, str] | None:
     order_id = body.get("orderID") or ""
     label = "fak-no-fill" if "fak" in err else "fok-no-fill"
     return order_id, label
+
+
+def _classify_post_only_cross_error(exc: Exception) -> tuple[str, str] | None:
+    """If `exc` is a v2-server post-only-would-cross rejection, return
+    (order_id, label). Returns None otherwise.
+
+    Polymarket's v2 server raises HTTP 400 (PolyApiException) when a
+    post-only order would have crossed the book at placement — the only
+    pattern of post-only-rejection we expect at runtime. Token-matches on
+    "post" + ("only" or "cross") in the error message — the exact server
+    string is confirmed empirically in the Step-9 dry-run probe of the
+    2026-05-15 post-only-entries implementation plan.
+    """
+    if not isinstance(exc, PolyApiException) or exc.status_code != 400:
+        return None
+    body = exc.error_msg
+    if not isinstance(body, dict):
+        return None
+    err = (body.get("error") or "").lower()
+    if "post" not in err or ("only" not in err and "cross" not in err):
+        return None
+    order_id = body.get("orderID") or ""
+    return order_id, "post-only-would-cross"
 
 
 def fok_limit_price(price: float) -> float:
@@ -125,6 +149,32 @@ def ioc_limit_price(
         return None
     best_opp = max(float(b["price"]) for b in opp_bids)
     return round(min(0.99, (1.0 - best_opp) + buffer_ticks * 0.01), 2)
+
+
+def post_only_rest_price(
+    side: str,
+    up_bids: list[dict] | None,
+    down_bids: list[dict] | None,
+    offset_ticks: int,
+) -> float | None:
+    """Maker rest price for a BUY UP/DOWN on a binary book.
+
+    Sits `offset_ticks` below the pair-merge clearing `pmc = 1 - best_opp_bid`.
+    Returns None when the opposite book has no bid (no pair-merge counterparty
+    exists; caller should skip with 'no-pair-merge-counterparty'). Floored at
+    $0.01 — a rest at $0.00 is meaningless. Capped at $0.99 to mirror the FAK
+    limit convention.
+
+    Conservatively: a non-positive offset_ticks would request a rest at-or-
+    above the cross, which post-only would reject server-side. Caller's
+    responsibility to keep offset_ticks >= 1; this function trusts the input.
+    """
+    opp_bids = down_bids if side == "up" else up_bids
+    if not opp_bids:
+        return None
+    best_opp = max(float(b["price"]) for b in opp_bids)
+    rest = (1.0 - best_opp) - offset_ticks * 0.01
+    return round(max(0.01, min(0.99, rest)), 2)
 
 
 class PolymarketClient:
@@ -315,6 +365,95 @@ class PolymarketClient:
             status="filled", order_id=order_id,
             filled_size=info.shares_held, avg_price=avg_price, error=None,
         )
+
+    def submit_post_only(
+        self, side, size, price, token_id, condition_id, expiration,
+    ):
+        """Post a GTC limit order with post_only=True.
+
+        `size` is in shares (NOT USDC) — this differs from submit_ioc and
+        submit_fok whose `amount` field is the USDC budget. `expiration` is
+        a Unix-seconds timestamp; the server kills the resting order at
+        that time if it hasn't filled.
+
+        Returns PlaceResult:
+        - status="placed" on accepted (resting in book).
+        - status="rejected" on server-side rejection (e.g. would-cross).
+        - status="error" on network/signing failure.
+        """
+        if self._dry_run:
+            log.info(
+                "DRY-RUN submit_post_only side=%s size=%.2f price=%.4f exp=%d "
+                "token=%s cond=%s",
+                side, size, price, expiration, token_id, condition_id,
+            )
+            return PlaceResult(status="placed", order_id="DRY-RUN", error=None)
+
+        # Tick-safe quantization — same defense-in-depth as submit_ioc.
+        target_size_int = max(1, int(round(size)))
+        size_int = _tick_safe_size(target_size_int, price)
+        if size_int is None:
+            log.error(
+                "submit_post_only: no tick-safe size near %d for price=%.4f",
+                target_size_int, price,
+            )
+            return PlaceResult(
+                status="rejected", order_id=None, error="tick-size-unfixable",
+            )
+
+        # OrderArgsV2.side is annotated `str` but the SDK accepts the
+        # IntEnum directly. str(Side.BUY) would produce "Side.BUY" — wrong.
+        # Mirrors the FAK path's MarketOrderArgs(side=Side.BUY).
+        args = OrderArgs(
+            token_id=token_id,
+            price=price,
+            size=float(size_int),
+            side=Side.BUY,
+            expiration=int(expiration),
+        )
+        try:
+            resp = self._client.create_and_post_order(
+                order_args=args,
+                options=PartialCreateOrderOptions(tick_size=TICK_SIZE),
+                order_type=OrderType.GTC,
+                post_only=True,
+            )
+        except Exception as exc:
+            cross = _classify_post_only_cross_error(exc)
+            if cross is not None:
+                order_id, label = cross
+                return PlaceResult(
+                    status="rejected", order_id=order_id or None, error=label,
+                )
+            log.exception("submit_post_only network/signing error")
+            return PlaceResult(
+                status="error", order_id=None, error=f"network: {exc}",
+            )
+
+        # v2 success response (live resting order): {"success": True,
+        #   "orderID": "...", "status": "live", "makingAmount": ...,
+        #   "takingAmount": ..., "transactionsHashes": [], "tradeIDs": []}.
+        if not resp.get("success"):
+            err = resp.get("errorMsg") or f"status={resp.get('status')!r}"
+            # Server-level post-only-cross can also arrive as success=False
+            # with errorMsg text (not always as a 400 PolyApiException).
+            lower = err.lower() if isinstance(err, str) else ""
+            if "post" in lower and ("only" in lower or "cross" in lower):
+                return PlaceResult(
+                    status="rejected", order_id=resp.get("orderID") or None,
+                    error="post-only-would-cross",
+                )
+            return PlaceResult(
+                status="rejected", order_id=resp.get("orderID") or None, error=err,
+            )
+
+        order_id = resp.get("orderID")
+        if not order_id:
+            return PlaceResult(
+                status="rejected", order_id=None, error="no-order-id",
+            )
+
+        return PlaceResult(status="placed", order_id=order_id, error=None)
 
     def cancel_order(self, order_id: str) -> bool:
         """Cancel a resting order. Retries on transient errors.

--- a/polypocket/clients/polymarket.py
+++ b/polypocket/clients/polymarket.py
@@ -532,17 +532,25 @@ class PolymarketClient:
     def get_settlement_info(self, order_id: str) -> SettlementInfo:
         """Look up the CLOB record of a filled order and return real fill accounting.
 
-        Reads per-fill data from the /trades endpoint rather than /order, because
-        Polymarket's pair-matching means a BUY Up can fill against a BUY Down
-        maker — the taker's true per-share price is (1 - maker_price), which
-        does NOT appear as a field on the /order response. /order.price on a
-        filled market BUY reflects the order's limit rounding, not the fill
-        rate, so `size_matched × order.price` overstates cost when matched
-        via the pair-merge path (observed on live trade: order.price=0.48 but
-        the real taker fill was 0.41).
+        Reads per-fill data from the /trades endpoint. A single trade event on
+        Polymarket can involve one taker and multiple makers (each with their
+        own slice of the match); the response includes a top-level
+        `taker_order_id` plus a `maker_orders[]` array. Our order can appear
+        on either side:
 
-        shares_held = sum(trade.size × (1 - trade.fee_rate_bps/10000))
-        cost_usdc   = sum(trade.size × trade.price)
+        - **Taker path** (FAK / FOK orders): our order_id == taker_order_id.
+          Our portion of the fill is the top-level `size` and `price`.
+        - **Maker path** (post-only / GTC rests): our order_id appears as
+          `maker_orders[i].order_id`. Our portion is that entry's
+          `matched_amount` and `price`. CRITICAL: the top-level `size` is the
+          TOTAL match across all makers, not our slice — using it would
+          overcount by an order of magnitude. (Empirical: cohort run
+          2026-05-16 silently lost ~$25 because the taker-only filter here
+          returned shares_held=0 for every post-only fill, so the bot wrote
+          them as rejected; the maker-side fills settled in the background.)
+
+        shares_held / cost_usdc are summed across all matches the order
+        participated in (handles partial fills across multiple events).
         """
         if self._dry_run or order_id == "DRY-RUN":
             return SettlementInfo(shares_held=0.0, cost_usdc=0.0)
@@ -560,11 +568,27 @@ class PolymarketClient:
         for tid in trade_ids:
             fills = self._client.get_trades(TradeParams(id=tid))
             for fill in fills:
-                if fill.get("taker_order_id") != order_id:
+                # Taker path
+                if fill.get("taker_order_id") == order_id:
+                    size = float(fill.get("size", 0.0) or 0.0)
+                    price = float(fill.get("price", 0.0) or 0.0)
+                    fee_bps = float(fill.get("fee_rate_bps", 0) or 0)
+                    shares_held += size * (1.0 - fee_bps / 10_000.0)
+                    cost_usdc += size * price
                     continue
-                size = float(fill.get("size", 0.0) or 0.0)
-                price = float(fill.get("price", 0.0) or 0.0)
-                fee_bps = float(fill.get("fee_rate_bps", 0) or 0)
-                shares_held += size * (1.0 - fee_bps / 10_000.0)
-                cost_usdc += size * price
+                # Maker path: walk maker_orders[] looking for our slice
+                for mo in (fill.get("maker_orders") or []):
+                    if not isinstance(mo, dict) or mo.get("order_id") != order_id:
+                        continue
+                    size = float(mo.get("matched_amount", 0.0) or 0.0)
+                    price = float(mo.get("price", 0.0) or 0.0)
+                    # maker_orders[].fee_rate_bps is often empty string on
+                    # successful matches; treat falsy as 0.
+                    fee_raw = mo.get("fee_rate_bps", 0)
+                    try:
+                        fee_bps = float(fee_raw) if fee_raw not in (None, "") else 0.0
+                    except (TypeError, ValueError):
+                        fee_bps = 0.0
+                    shares_held += size * (1.0 - fee_bps / 10_000.0)
+                    cost_usdc += size * price
         return SettlementInfo(shares_held=shares_held, cost_usdc=cost_usdc)

--- a/polypocket/clients/polymarket.py
+++ b/polypocket/clients/polymarket.py
@@ -414,11 +414,17 @@ class PolymarketClient:
             side=Side.BUY,
             expiration=int(expiration),
         )
+        # Empirical (Step-9 live probe 2026-05-16): the server rejects GTC
+        # with a non-zero expiration ("invalid expiration value (...), it
+        # should be equal to '0' as the order is not a GTD order"). Use GTD
+        # when we want a server-side expiration safety net, GTC only when
+        # expiration is 0 (no safety net — bot must drive cancel).
+        order_type = OrderType.GTD if int(expiration) > 0 else OrderType.GTC
         try:
             resp = self._client.create_and_post_order(
                 order_args=args,
                 options=PartialCreateOrderOptions(tick_size=TICK_SIZE),
-                order_type=OrderType.GTC,
+                order_type=order_type,
                 post_only=True,
             )
         except Exception as exc:

--- a/polypocket/clients/polymarket.py
+++ b/polypocket/clients/polymarket.py
@@ -363,6 +363,21 @@ class PolymarketClient:
             return {}
         return self._client.get_order(order_id)
 
+    def get_order_book(self, token_id: str) -> dict:
+        """Fetch the live order book for a token. Best-effort diagnostic call.
+
+        Returns `{}` on dry-run or any SDK/network error so a fetch failure
+        never breaks the trade flow — this is called post-submit purely for
+        the adverse-selection diagnostic.
+        """
+        if self._dry_run:
+            return {}
+        try:
+            return self._client.get_order_book(token_id) or {}
+        except Exception as exc:
+            log.warning("get_order_book failed for %s: %s", token_id, exc)
+            return {}
+
     def get_settlement_info(self, order_id: str) -> SettlementInfo:
         """Look up the CLOB record of a filled order and return real fill accounting.
 

--- a/polypocket/clients/polymarket.py
+++ b/polypocket/clients/polymarket.py
@@ -387,7 +387,10 @@ class PolymarketClient:
                 "token=%s cond=%s",
                 side, size, price, expiration, token_id, condition_id,
             )
-            return PlaceResult(status="placed", order_id="DRY-RUN", error=None)
+            return PlaceResult(
+                status="placed", order_id="DRY-RUN", error=None,
+                placed_size=float(size),
+            )
 
         # Tick-safe quantization — same defense-in-depth as submit_ioc.
         target_size_int = max(1, int(round(size)))
@@ -453,7 +456,10 @@ class PolymarketClient:
                 status="rejected", order_id=None, error="no-order-id",
             )
 
-        return PlaceResult(status="placed", order_id=order_id, error=None)
+        return PlaceResult(
+            status="placed", order_id=order_id, error=None,
+            placed_size=float(size_int),
+        )
 
     def cancel_order(self, order_id: str) -> bool:
         """Cancel a resting order. Retries on transient errors.

--- a/polypocket/config.py
+++ b/polypocket/config.py
@@ -110,6 +110,28 @@ FOK_SLIPPAGE_TICKS = int(os.getenv("FOK_SLIPPAGE_TICKS", "3"))
 # fills) produced median slip 6¢ vs 11.6¢ at buffer=15 — SHIP verdict per
 # design doc. See #14, closes #12.
 IOC_BUFFER_TICKS = int(os.getenv("IOC_BUFFER_TICKS", "8"))
+# Execution mode for live trades. "fak" keeps the current pair-merge taker
+# (FAK-via-v2 SDK) path; "post_only" routes through a GTC + post_only
+# resting maker order. Paper mode ignores this entirely. Default "fak"
+# until the post-only path completes paper-replay + dry-run probe + small
+# live cohort validation per the 2026-05-15 post-only-entries design.
+ENTRY_MODE = os.getenv("ENTRY_MODE", "fak").strip().lower()
+# Ticks below the pair-merge clearing price (1 - best_opp_bid) to rest a
+# post-only maker order. Default 2: absorbs typical 200-500ms book drift
+# between gate-eval and SDK sign while still capturing ~7 ticks of edge
+# over the FAK regime's `pmc + IOC_BUFFER_TICKS`. Tune from cohort data
+# after the first 50-100 fills land.
+POST_ONLY_REST_OFFSET_TICKS = int(os.getenv("POST_ONLY_REST_OFFSET_TICKS", "2"))
+# Wall-clock seconds-remaining at which the bot tick cancels a resting
+# post-only order. Matches WINDOW_ENTRY_MIN_REMAINING so a post-only fill
+# never lands inside the dead-band where the gate refuses new signals.
+POST_ONLY_CANCEL_AT_T_REMAINING_S = float(os.getenv("POST_ONLY_CANCEL_AT_T_REMAINING_S", "30"))
+# Seconds subtracted from window.end_time when computing the server-side
+# order `expiration` field. Defense-in-depth against a bot tick that
+# misses its cancel deadline — server kills the order if the bot is
+# silent through the boundary. Same nominal value as the bot-side
+# threshold by design.
+POST_ONLY_EXPIRY_SAFETY_BUFFER_S = float(os.getenv("POST_ONLY_EXPIRY_SAFETY_BUFFER_S", "30"))
 # Fraction of book depth (at <= FOK limit price) we ask for as our FOK
 # size. Leaves headroom for the book to thin between our depth read and
 # the signed order reaching the matcher. 0.9 = ask for at most 90% of
@@ -150,6 +172,10 @@ def snapshot_gate_config() -> dict:
         "SIGNAL_CUSHION_TICKS": SIGNAL_CUSHION_TICKS,
         "IOC_BUFFER_TICKS": IOC_BUFFER_TICKS,
         "FOK_SLIPPAGE_TICKS": FOK_SLIPPAGE_TICKS,
+        "ENTRY_MODE": ENTRY_MODE,
+        "POST_ONLY_REST_OFFSET_TICKS": POST_ONLY_REST_OFFSET_TICKS,
+        "POST_ONLY_CANCEL_AT_T_REMAINING_S": POST_ONLY_CANCEL_AT_T_REMAINING_S,
+        "POST_ONLY_EXPIRY_SAFETY_BUFFER_S": POST_ONLY_EXPIRY_SAFETY_BUFFER_S,
         "DEPTH_CLAMP_BUFFER": DEPTH_CLAMP_BUFFER,
         "MIN_FILL_RATIO": MIN_FILL_RATIO,
         "MAX_BOOK_AGE_S": MAX_BOOK_AGE_S,

--- a/polypocket/config.py
+++ b/polypocket/config.py
@@ -129,9 +129,19 @@ POST_ONLY_CANCEL_AT_T_REMAINING_S = float(os.getenv("POST_ONLY_CANCEL_AT_T_REMAI
 # Seconds subtracted from window.end_time when computing the server-side
 # order `expiration` field. Defense-in-depth against a bot tick that
 # misses its cancel deadline — server kills the order if the bot is
-# silent through the boundary. Same nominal value as the bot-side
-# threshold by design.
-POST_ONLY_EXPIRY_SAFETY_BUFFER_S = float(os.getenv("POST_ONLY_EXPIRY_SAFETY_BUFFER_S", "30"))
+# silent through the boundary. Default 60 mirrors the server's own
+# security threshold (see POLYMARKET_MIN_EXPIRATION_BUFFER_S): the
+# server rejects any expiration value less than now + 60s with a 400
+# (empirical, Step-9 probe 2026-05-16).
+POST_ONLY_EXPIRY_SAFETY_BUFFER_S = float(os.getenv("POST_ONLY_EXPIRY_SAFETY_BUFFER_S", "60"))
+# Polymarket's server-side security threshold for GTD `expiration` values.
+# Any expiration < now + 60s is rejected with HTTP 400. The bot computes
+# expiration = window.end_time - POST_ONLY_EXPIRY_SAFETY_BUFFER_S; when
+# that falls below `now + this + safety`, the dispatch site floors to a
+# server-accepted value (bot-side cancel handles window-end protection
+# in that band). 65 = 60s threshold + 5s safety against clock skew /
+# request transit time.
+POLYMARKET_MIN_EXPIRATION_BUFFER_S = float(os.getenv("POLYMARKET_MIN_EXPIRATION_BUFFER_S", "65"))
 # Fraction of book depth (at <= FOK limit price) we ask for as our FOK
 # size. Leaves headroom for the book to thin between our depth read and
 # the signed order reaching the matcher. 0.9 = ask for at most 90% of
@@ -176,6 +186,7 @@ def snapshot_gate_config() -> dict:
         "POST_ONLY_REST_OFFSET_TICKS": POST_ONLY_REST_OFFSET_TICKS,
         "POST_ONLY_CANCEL_AT_T_REMAINING_S": POST_ONLY_CANCEL_AT_T_REMAINING_S,
         "POST_ONLY_EXPIRY_SAFETY_BUFFER_S": POST_ONLY_EXPIRY_SAFETY_BUFFER_S,
+        "POLYMARKET_MIN_EXPIRATION_BUFFER_S": POLYMARKET_MIN_EXPIRATION_BUFFER_S,
         "DEPTH_CLAMP_BUFFER": DEPTH_CLAMP_BUFFER,
         "MIN_FILL_RATIO": MIN_FILL_RATIO,
         "MAX_BOOK_AGE_S": MAX_BOOK_AGE_S,

--- a/polypocket/executor.py
+++ b/polypocket/executor.py
@@ -40,6 +40,16 @@ class FillResult:
 
 
 @dataclass(frozen=True)
+class PlaceResult:
+    """Outcome of a post-only place request. Distinct from FillResult, which
+    represents terminal fills; a PlaceResult represents the order's
+    acceptance into the book (or its rejection at placement)."""
+    status: Literal["placed", "rejected", "error"]
+    order_id: str | None
+    error: str | None
+
+
+@dataclass(frozen=True)
 class SettlementInfo:
     """Post-fill, post-resolution accounting pulled from the CLOB.
 
@@ -59,6 +69,10 @@ class LiveOrderClient(Protocol):
         self, side: str, price: float, size: float,
         token_id: str, condition_id: str, limit_price: float,
     ) -> FillResult: ...
+    def submit_post_only(
+        self, side: str, size: float, price: float,
+        token_id: str, condition_id: str, expiration: int,
+    ) -> PlaceResult: ...
     def cancel_order(self, order_id: str) -> bool: ...
     def get_usdc_balance(self) -> float: ...
     def get_settlement_info(self, order_id: str) -> SettlementInfo: ...
@@ -177,6 +191,18 @@ def reconcile_recovered_trade(
             external_order_id=order_id,
         )
         return "rejected"
+
+    if clob_status == "live":
+        # A post-only resting order from a previous run is still on the
+        # book. Window context is gone; cancel-and-reconcile inline so the
+        # order doesn't fill into the new window.
+        log_order_event(
+            db_path, trade["id"], trade["window_slug"], "reconcile_live",
+            time.time(),
+            payload={"from_status": current_status, "clob_status": clob_status},
+            external_order_id=order_id,
+        )
+        return cancel_post_only_order(db_path, trade, client, trigger="crash-recovery")
 
     log.warning(
         "reconcile: unexpected CLOB status %r for trade %s order %s; keeping local %r",
@@ -448,6 +474,250 @@ def execute_live_trade(
         window_slug, signal.side, entry_price, size, fill.error,
     )
     return TradeResult(success=False, trade_id=trade_id, error=fill.error)
+
+
+def execute_live_trade_post_only(
+    db_path: str,
+    signal: Signal,
+    intended_size: float,
+    window_slug: str,
+    token_id: str,
+    condition_id: str,
+    client: LiveOrderClient,
+    *,
+    up_bids: list[dict] | None,
+    down_bids: list[dict] | None,
+    offset_ticks: int,
+    expiration: int,
+    submit_book_age_s_monotonic: float | None = None,
+) -> TradeResult:
+    """Place a post-only resting maker order at pmc - offset_ticks.
+
+    Computes rest_price inside this function from the bids passed by the
+    caller — the place-time recompute step. (A future enhancement may
+    refresh the bids via client.get_order_book here for even-fresher pmc;
+    out of v1 scope.) Returns None / 'no-pair-merge-counterparty' if no
+    opposite-side bid is available.
+
+    On successful placement, the trade row sits at status='placed' with
+    size=intended_size and entry_price=rest_price (intended values). The
+    realized fill is reconciled when cancel_post_only_order runs at
+    window-close / crash-recovery.
+    """
+    from polypocket.clients.polymarket import post_only_rest_price
+
+    existing_trade = find_trade_by_window_slug(db_path, window_slug)
+    if existing_trade is not None:
+        return _window_consumed_result(db_path, window_slug)
+
+    rest_price = post_only_rest_price(signal.side, up_bids, down_bids, offset_ticks)
+    if rest_price is None:
+        return TradeResult(success=False, error="no-pair-merge-counterparty")
+
+    usdc_needed = rest_price * intended_size
+    if client.get_usdc_balance() < usdc_needed:
+        return TradeResult(success=False, error="insufficient-balance")
+
+    fee_sh = fee_shares(intended_size, rest_price)
+    try:
+        trade_id = log_trade(
+            db_path=db_path,
+            window_slug=window_slug,
+            side=signal.side,
+            entry_price=rest_price,
+            size=intended_size,
+            fees=fee_sh,
+            model_p_up=signal.model_p_up,
+            market_p_up=signal.market_price,
+            edge=signal.edge,
+            outcome=None,
+            pnl=None,
+            status="placed",
+            signal_reference_price=signal.signal_reference_price,
+            signal_reference_source="live",
+            entry_mode="post_only",
+            rest_price=rest_price,
+        )
+    except sqlite3.IntegrityError:
+        consumed = _window_consumed_result(db_path, window_slug)
+        if consumed.trade_id is not None:
+            return consumed
+        raise
+
+    log_order_event(
+        db_path, trade_id, window_slug, "place", time.time(),
+        payload={
+            "side": signal.side,
+            "intended_size": intended_size,
+            "rest_price": rest_price,
+            "offset_ticks": offset_ticks,
+            "expiration": expiration,
+            "signal_reference_price": signal.signal_reference_price,
+            "book_age_s_monotonic": submit_book_age_s_monotonic,
+        },
+    )
+    place = client.submit_post_only(
+        side=signal.side, size=intended_size, price=rest_price,
+        token_id=token_id, condition_id=condition_id, expiration=expiration,
+    )
+    log_order_event(
+        db_path, trade_id, window_slug, "ack", time.time(),
+        payload={"status": place.status, "error": place.error},
+        external_order_id=place.order_id,
+    )
+
+    if place.status == "rejected":
+        update_trade(
+            db_path, trade_id, outcome=None, pnl=None, status="rejected",
+            external_order_id=place.order_id, error=place.error,
+        )
+        log_order_event(
+            db_path, trade_id, window_slug, "reject", time.time(),
+            payload={"error": place.error},
+            external_order_id=place.order_id,
+        )
+        log.warning(
+            "post-only reject: %s %s @%.4f x%.2f: %s",
+            window_slug, signal.side, rest_price, intended_size, place.error,
+        )
+        return TradeResult(success=False, trade_id=trade_id, error=place.error)
+
+    if place.status == "error":
+        update_trade(
+            db_path, trade_id, outcome=None, pnl=None, status="rejected",
+            external_order_id=place.order_id, error=place.error,
+        )
+        return TradeResult(success=False, trade_id=trade_id, error=place.error)
+
+    # status == "placed"
+    update_trade(
+        db_path, trade_id, outcome=None, pnl=None, status="placed",
+        external_order_id=place.order_id,
+    )
+    log.info(
+        "post-only PLACED: %s %s rest=$%.4f x%.2f exp=%d token=%s order=%s",
+        window_slug, signal.side, rest_price, intended_size,
+        expiration, token_id, place.order_id,
+    )
+    return TradeResult(success=True, trade_id=trade_id, pnl=None)
+
+
+def cancel_post_only_order(
+    db_path: str,
+    trade: dict,
+    client: LiveOrderClient,
+    trigger: str,
+) -> str:
+    """Cancel a resting post-only order and reconcile via /trades.
+
+    `get_settlement_info` is called post-cancel regardless of cancel
+    success — even on a cancel race where partial fills landed in the
+    submit→cancel window, the CLOB state is authoritative.
+
+    Returns final local status: 'open' (partial-or-full fill, settles
+    later at window close) or 'rejected' (no fill, post-only-no-fill).
+    On settlement-lookup failure, preserves the prior status so a future
+    reconciler pass can retry.
+    """
+    trade_id = trade["id"]
+    window_slug = trade["window_slug"]
+    order_id = trade.get("external_order_id")
+    if not order_id:
+        log.warning("cancel_post_only_order: no order_id on trade %s", trade_id)
+        return trade.get("status", "placed")
+
+    log_order_event(
+        db_path, trade_id, window_slug, "cancel", time.time(),
+        payload={"trigger": trigger, "phase": "request"},
+        external_order_id=order_id,
+    )
+    cancel_ok = False
+    try:
+        cancel_ok = client.cancel_order(order_id)
+    except Exception as exc:
+        log.warning(
+            "cancel_post_only_order: cancel_order raised for %s: %s", order_id, exc,
+        )
+
+    try:
+        info = client.get_settlement_info(order_id)
+    except Exception as exc:
+        log.exception(
+            "cancel_post_only_order: get_settlement_info failed for %s: %s",
+            order_id, exc,
+        )
+        log_order_event(
+            db_path, trade_id, window_slug, "cancel", time.time(),
+            payload={
+                "trigger": trigger, "phase": "ack",
+                "cancel_success": cancel_ok,
+                "settlement_lookup_error": str(exc),
+            },
+            external_order_id=order_id,
+        )
+        return trade.get("status", "placed")
+
+    log_order_event(
+        db_path, trade_id, window_slug, "cancel", time.time(),
+        payload={
+            "trigger": trigger, "phase": "ack",
+            "cancel_success": cancel_ok,
+            "shares_held": info.shares_held,
+            "cost_usdc": info.cost_usdc,
+        },
+        external_order_id=order_id,
+    )
+
+    if info.shares_held > 0:
+        avg_price = info.cost_usdc / info.shares_held
+        update_trade(
+            db_path, trade_id, outcome=None, pnl=None, status="open",
+            size=info.shares_held, entry_price=avg_price,
+        )
+        # update_trade's error column is COALESCE-preserved; clear stale
+        # error text from earlier transitions so the promoted-to-open row
+        # reads cleanly on post-mortem. Mirrors reconcile_recovered_trade's
+        # stranded-fill branch.
+        with closing(sqlite3.connect(db_path)) as conn:
+            conn.execute(
+                "UPDATE trades SET error = NULL WHERE id = ?", (trade_id,),
+            )
+            conn.commit()
+        notional = info.shares_held * avg_price
+        if notional < MIN_POSITION_USDC * 0.25:
+            log.warning(
+                "post-only dust-fill %s: %.4f @ $%.4f = $%.4f < floor=$%.4f",
+                window_slug, info.shares_held, avg_price, notional,
+                MIN_POSITION_USDC * 0.25,
+            )
+        log_order_event(
+            db_path, trade_id, window_slug, "fill", time.time(),
+            payload={
+                "filled_size": info.shares_held, "avg_price": avg_price,
+                "via": "cancel-reconcile",
+            },
+            external_order_id=order_id,
+        )
+        log.info(
+            "post-only FILLED via cancel-reconcile: %s %s %.4f @ $%.4f",
+            window_slug, trade["side"], info.shares_held, avg_price,
+        )
+        return "open"
+
+    update_trade(
+        db_path, trade_id, outcome=None, pnl=None, status="rejected",
+        error="post-only-no-fill",
+    )
+    log_order_event(
+        db_path, trade_id, window_slug, "reject", time.time(),
+        payload={"error": "post-only-no-fill"},
+        external_order_id=order_id,
+    )
+    log.info(
+        "post-only NO-FILL: %s order=%s trigger=%s",
+        window_slug, order_id, trigger,
+    )
+    return "rejected"
 
 
 def settle_paper_trade(

--- a/polypocket/executor.py
+++ b/polypocket/executor.py
@@ -43,10 +43,18 @@ class FillResult:
 class PlaceResult:
     """Outcome of a post-only place request. Distinct from FillResult, which
     represents terminal fills; a PlaceResult represents the order's
-    acceptance into the book (or its rejection at placement)."""
+    acceptance into the book (or its rejection at placement).
+
+    `placed_size` is the size actually placed on the server (after the SDK
+    wrapper's tick-safe integer quantization). Differs from the caller's
+    intended_size by up to ±6 — the executor must update the trade row to
+    this value so the local ledger matches what's resting on the book.
+    None on non-placed outcomes.
+    """
     status: Literal["placed", "rejected", "error"]
     order_id: str | None
     error: str | None
+    placed_size: float | None = None
 
 
 @dataclass(frozen=True)
@@ -589,14 +597,20 @@ def execute_live_trade_post_only(
         )
         return TradeResult(success=False, trade_id=trade_id, error=place.error)
 
-    # status == "placed"
+    # status == "placed". The SDK wrapper may have quantized size to a
+    # tick-safe integer that differs from intended_size by ±6 — overwrite
+    # the trade row's size with the actual placed size so the local ledger
+    # matches what's resting on the book. Falls back to intended_size if
+    # the wrapper didn't surface a placed_size (e.g. test doubles).
+    effective_size = place.placed_size if place.placed_size is not None else intended_size
     update_trade(
         db_path, trade_id, outcome=None, pnl=None, status="placed",
         external_order_id=place.order_id,
+        size=effective_size,
     )
     log.info(
         "post-only PLACED: %s %s rest=$%.4f x%.2f exp=%d token=%s order=%s",
-        window_slug, signal.side, rest_price, intended_size,
+        window_slug, signal.side, rest_price, effective_size,
         expiration, token_id, place.order_id,
     )
     return TradeResult(success=True, trade_id=trade_id, pnl=None)

--- a/polypocket/executor.py
+++ b/polypocket/executor.py
@@ -63,6 +63,7 @@ class LiveOrderClient(Protocol):
     def get_usdc_balance(self) -> float: ...
     def get_settlement_info(self, order_id: str) -> SettlementInfo: ...
     def get_order_status(self, order_id: str) -> dict: ...
+    def get_order_book(self, token_id: str) -> dict: ...
 
 
 def reconcile_recovered_trade(
@@ -284,6 +285,24 @@ def execute_paper_trade(
     return TradeResult(success=True, trade_id=trade_id, pnl=pnl)
 
 
+def _book_top_n(book: dict, n: int = 3) -> dict:
+    """Compress a /book response to top-N levels on each side, plus timestamp.
+
+    The v2 /book endpoint returns dicts of stringified prices/sizes already
+    sorted best-first per side. We keep just the head — full depth would
+    bloat order_events payloads and we only need the top for the adverse-
+    selection diagnostic.
+    """
+    if not isinstance(book, dict):
+        return {}
+    return {
+        "bids": (book.get("bids") or [])[:n],
+        "asks": (book.get("asks") or [])[:n],
+        "timestamp": book.get("timestamp"),
+        "hash": book.get("hash"),
+    }
+
+
 def execute_live_trade(
     db_path: str,
     signal: Signal,
@@ -295,6 +314,7 @@ def execute_live_trade(
     client: LiveOrderClient,
     limit_price: float,
     submit_book_age_s_monotonic: float | None = None,
+    opposite_token_id: str | None = None,
 ) -> TradeResult:
     existing_trade = find_trade_by_window_slug(db_path, window_slug)
     if existing_trade is not None:
@@ -350,9 +370,39 @@ def execute_live_trade(
         condition_id=condition_id,
         limit_price=limit_price,
     )
+    # Ack-time book snapshot: best-effort fresh REST read of both tokens'
+    # books so analyses can measure book drift across the submit→ack window
+    # (the asyncio loop is blocked during submit_ioc, so the bot's locally
+    # cached book can't update). Any fetch failure is swallowed — this is a
+    # diagnostic, never a trade blocker.
+    book_at_ack: dict | None = None
+    book_fetched_at_wall: float | None = None
+    try:
+        side_book = client.get_order_book(token_id)
+        opp_book = (
+            client.get_order_book(opposite_token_id)
+            if opposite_token_id else {}
+        )
+        book_fetched_at_wall = time.time()
+        if signal.side == "up":
+            book_at_ack = {
+                "up_book": _book_top_n(side_book),
+                "down_book": _book_top_n(opp_book),
+            }
+        else:
+            book_at_ack = {
+                "up_book": _book_top_n(opp_book),
+                "down_book": _book_top_n(side_book),
+            }
+    except Exception as exc:
+        log.warning("ack-time book snapshot failed: %s", exc)
+    ack_payload: dict = {"status": fill.status, "error": fill.error}
+    if book_at_ack is not None:
+        ack_payload["book_at_ack"] = book_at_ack
+        ack_payload["book_fetched_at_wall"] = book_fetched_at_wall
     log_order_event(
         db_path, trade_id, window_slug, "ack", time.time(),
-        payload={"status": fill.status, "error": fill.error},
+        payload=ack_payload,
         external_order_id=fill.order_id,
     )
 

--- a/polypocket/ledger.py
+++ b/polypocket/ledger.py
@@ -78,6 +78,10 @@ def init_db(db_path: str) -> None:
                 conn.execute("ALTER TABLE trades ADD COLUMN signal_reference_price REAL")
             if "signal_reference_source" not in existing_cols:
                 conn.execute("ALTER TABLE trades ADD COLUMN signal_reference_source TEXT")
+            if "entry_mode" not in existing_cols:
+                conn.execute("ALTER TABLE trades ADD COLUMN entry_mode TEXT")
+            if "rest_price" not in existing_cols:
+                conn.execute("ALTER TABLE trades ADD COLUMN rest_price REAL")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS window_snapshots (
@@ -263,6 +267,8 @@ def log_trade(
     status: str,
     signal_reference_price: float | None = None,
     signal_reference_source: str | None = None,
+    entry_mode: str | None = None,
+    rest_price: float | None = None,
 ) -> int:
     with closing(sqlite3.connect(db_path)) as conn:
         cursor = conn.execute(
@@ -270,8 +276,9 @@ def log_trade(
             INSERT INTO trades (
                 window_slug, side, entry_price, size, fees,
                 model_p_up, market_p_up, edge, outcome, pnl, status,
-                signal_reference_price, signal_reference_source
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                signal_reference_price, signal_reference_source,
+                entry_mode, rest_price
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 window_slug,
@@ -287,6 +294,8 @@ def log_trade(
                 status,
                 signal_reference_price,
                 signal_reference_source,
+                entry_mode,
+                rest_price,
             ),
         )
         conn.commit()

--- a/polypocket/ledger.py
+++ b/polypocket/ledger.py
@@ -238,14 +238,19 @@ def get_open_trade_by_window_slug(db_path: str, window_slug: str) -> dict | None
 
 
 def find_unsettled_trades(db_path: str) -> list[dict]:
-    """Return all trades with status 'open' or 'reserved' (not yet settled)."""
+    """Return all trades with status 'open', 'reserved', or 'placed'.
+
+    'placed' covers a resting post-only order that survived a bot-down-through-
+    window scenario — without it, the row is orphaned at startup and never
+    reconciled even after the server-side expiration kills the order.
+    """
     with closing(sqlite3.connect(db_path)) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
             """
             SELECT *
             FROM trades
-            WHERE status IN ('open', 'reserved')
+            WHERE status IN ('open', 'reserved', 'placed')
             ORDER BY id
             """,
         ).fetchall()

--- a/scripts/_post_only_replay.md
+++ b/scripts/_post_only_replay.md
@@ -1,0 +1,34 @@
+# Post-only paper replay — 2026-05-16 04:10:22 UTC
+
+- DB: `paper_trades.db`
+- offset_ticks: `2`
+- cancel_buffer_s: `30.0`
+
+## Fill statistics
+
+- Total decisions with bids JSON: **1671**
+- Eligible (pmc computable): **1669** (skipped 2 for missing opp bid)
+- Would-have-filled: **483**
+- Fill rate: **28.9%**
+- Median post-decision sample-index at fill: **1** (~30s after decision time)
+
+Note: book samples are at 30-second cadence; reported fill rate is a LOWER BOUND. Live data with sub-second granularity may show a higher fill rate.
+
+## Calibration (would-have-filled cohort only)
+
+| bin | n | mean p_pred | hit rate | gap |
+|---|---:|---:|---:|---:|
+| 0.50-0.55 | 2 | 0.543 | 0.000 | -0.543 |
+| 0.55-0.60 | 1 | 0.567 | 0.000 | -0.567 |
+| 0.60-0.65 | 9 | 0.636 | 0.556 | -0.080 |
+| 0.65-0.70 | 18 | 0.676 | 0.500 | -0.176 |
+| 0.70-0.75 | 62 | 0.720 | 0.371 | -0.349 |
+| 0.75-0.80 | 172 | 0.770 | 0.442 | -0.328 |
+| 0.80-0.85 | 73 | 0.821 | 0.397 | -0.424 |
+| 0.85-0.90 | 61 | 0.872 | 0.443 | -0.429 |
+| 0.90-0.95 | 38 | 0.926 | 0.421 | -0.505 |
+| 0.95-1.00 | 34 | 0.978 | 0.324 | -0.655 |
+
+## Acceptance check
+
+- Fill rate **28.9%** is in the plausible 15-80% band.

--- a/scripts/replay_post_only_paper.py
+++ b/scripts/replay_post_only_paper.py
@@ -1,0 +1,344 @@
+"""Post-hoc replay: what would the post-only execution path have filled,
+given the historical paper FAK cohort's decision snapshots and book samples?
+
+This honors the 2026-05-15 post-only-entries design's Phase-2 validation
+plan: deterministic replay against real recorded book data, no synthesized
+fillmodel. The runtime bot's paper path stays unchanged (FAK at ask); this
+script just asks "if the bot had been resting at pmc - offset_ticks instead,
+which of those decisions would have filled before the cancel boundary?"
+
+Reads from PAPER_DB_PATH (read-only). Emits scripts/_post_only_replay.md.
+
+Mechanism:
+1. For each window with a 'decision' snapshot + non-null up_bids_json /
+   down_bids_json + trade_fired=1, compute the would-be rest_price using
+   the project's `post_only_rest_price` helper at the current
+   POST_ONLY_REST_OFFSET_TICKS.
+2. Walk forward through `window_book_samples` rows for the same
+   window_slug, in chronological order. A fill is declared when any
+   sample's best_opp_bid >= 1 - rest_price (i.e., the implied clearing
+   has reached or crossed the rest level).
+3. Stop the walk at the cancel boundary
+   (window_end - POST_ONLY_CANCEL_AT_T_REMAINING_S). Fills after that
+   would have been pre-empted by the bot-side cancel in live mode.
+4. Join to trades.outcome for the windows where a fill is declared to
+   compute hypothetical calibration.
+
+Caveats:
+- Book samples are at 30-second cadence; a fill that happened intra-30s
+  is invisible. Reported fill rate is therefore a LOWER BOUND. Live data
+  with sub-second granularity may show a higher fill rate.
+- Replay assumes the bot's presence doesn't change other actors'
+  behavior. In live mode our resting maker may suppress/attract other
+  flow; the replay can't see that.
+- decision-time bids JSON is required. Coverage is partial across the
+  paper corpus (per the 2026-05-11 PnL attribution doc, ~27% of historical
+  rows had non-null bids JSON pre-G5; forward rows always have them).
+
+Run::
+
+    python scripts/replay_post_only_paper.py --offset-ticks 2
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sqlite3
+from contextlib import closing
+from datetime import datetime, timezone
+from pathlib import Path
+
+from polypocket.clients.polymarket import post_only_rest_price
+from polypocket.config import (
+    PAPER_DB_PATH,
+    POST_ONLY_CANCEL_AT_T_REMAINING_S,
+    POST_ONLY_REST_OFFSET_TICKS,
+)
+
+DEFAULT_BIN_WIDTH = 0.05
+DEFAULT_BIN_LO = 0.50
+DEFAULT_BIN_HI = 1.00
+
+
+def _load_decisions(conn: sqlite3.Connection) -> list[dict]:
+    """Eligible decisions: trade_fired=1 with both side-relevant bids JSON
+    populated. Joined to trades.outcome for the calibration check (a
+    decision without a settled trades row gets outcome=None, skipped from
+    calibration but counted toward fill rate).
+
+    `decision_ts` is converted from ISO text → Unix seconds at load-time
+    so downstream walks compare apples-to-apples with the REAL `sampled_at`
+    column in window_book_samples.
+    """
+    rows = conn.execute(
+        """
+        SELECT
+            ws.window_slug AS window_slug,
+            ws.preview_side AS preview_side,
+            ws.model_p_up AS model_p_up,
+            ws.up_bids_json AS up_bids_json,
+            ws.down_bids_json AS down_bids_json,
+            ws.timestamp AS decision_ts_iso,
+            t.outcome AS outcome
+        FROM window_snapshots ws
+        LEFT JOIN trades t ON t.window_slug = ws.window_slug
+        WHERE ws.snapshot_type = 'decision'
+          AND ws.trade_fired = 1
+          AND ws.up_bids_json IS NOT NULL
+          AND ws.down_bids_json IS NOT NULL
+        """
+    ).fetchall()
+    out = []
+    for r in rows:
+        up_bids = json.loads(r["up_bids_json"]) if r["up_bids_json"] else None
+        down_bids = json.loads(r["down_bids_json"]) if r["down_bids_json"] else None
+        try:
+            decision_ts = datetime.strptime(
+                r["decision_ts_iso"], "%Y-%m-%d %H:%M:%S",
+            ).replace(tzinfo=timezone.utc).timestamp()
+        except (ValueError, TypeError):
+            decision_ts = 0.0
+        out.append({
+            "window_slug": r["window_slug"],
+            "preview_side": r["preview_side"],
+            "model_p_up": r["model_p_up"],
+            "up_bids": up_bids,
+            "down_bids": down_bids,
+            "decision_ts": decision_ts,
+            "outcome": r["outcome"],
+        })
+    return out
+
+
+def _load_window_end(conn: sqlite3.Connection, slug: str) -> float | None:
+    """Best-effort window_end approximation: the latest book sample for
+    the slug rounded up to the next 5-minute boundary, or None if no
+    samples exist."""
+    row = conn.execute(
+        "SELECT MAX(sampled_at) AS last_ts FROM window_book_samples WHERE window_slug = ?",
+        (slug,),
+    ).fetchone()
+    if row is None or row["last_ts"] is None:
+        return None
+    last = float(row["last_ts"])
+    # Round up to the next 5-min boundary as the implied window_end.
+    return math.ceil(last / 300.0) * 300.0
+
+
+def _walk_samples_for_fill(
+    conn: sqlite3.Connection,
+    slug: str,
+    side: str,
+    rest_price: float,
+    decision_ts: float,
+    cancel_at_ts: float | None,
+) -> tuple[bool, int, float | None]:
+    """Walk window_book_samples chronologically *after* decision_ts. Return
+    (filled, sample_offset_at_fill, sample_ts_at_fill).
+    A fill is declared when best_opp_bid >= 1 - rest_price. Walk stops at
+    cancel_at_ts if provided. Pre-decision samples are skipped — the
+    rest order would not have existed yet."""
+    threshold = 1.0 - rest_price
+    rows = conn.execute(
+        """
+        SELECT sampled_at, up_bids_json, down_bids_json
+        FROM window_book_samples
+        WHERE window_slug = ?
+          AND sampled_at >= ?
+        ORDER BY sampled_at ASC
+        """,
+        (slug, decision_ts),
+    ).fetchall()
+    for i, r in enumerate(rows):
+        sampled_at = float(r["sampled_at"])
+        if cancel_at_ts is not None and sampled_at > cancel_at_ts:
+            return False, i, None
+        opp_bids_json = r["down_bids_json"] if side == "up" else r["up_bids_json"]
+        if not opp_bids_json:
+            continue
+        try:
+            opp_bids = json.loads(opp_bids_json)
+        except (TypeError, ValueError):
+            continue
+        if not opp_bids:
+            continue
+        best_opp = max(float(b["price"]) for b in opp_bids)
+        if best_opp >= threshold - 1e-9:
+            return True, i, sampled_at
+    return False, len(rows), None
+
+
+def _calibration_bin(p_up: float, bin_width: float, bin_lo: float, bin_hi: float) -> int | None:
+    if p_up is None:
+        return None
+    if p_up >= 0.5:
+        p_pred = p_up
+    else:
+        p_pred = 1.0 - p_up
+    if p_pred < bin_lo or p_pred >= bin_hi:
+        return None
+    return int((p_pred - bin_lo) / bin_width)
+
+
+def replay(
+    db_path: str,
+    offset_ticks: int,
+    cancel_buffer_s: float,
+    bin_width: float = DEFAULT_BIN_WIDTH,
+) -> dict:
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        decisions = _load_decisions(conn)
+        n_total = len(decisions)
+        results = []
+        n_no_pmc = 0
+        for d in decisions:
+            rest = post_only_rest_price(
+                d["preview_side"], d["up_bids"], d["down_bids"], offset_ticks,
+            )
+            if rest is None:
+                n_no_pmc += 1
+                results.append({
+                    **d, "rest_price": None, "filled": False,
+                    "fill_sample_index": None, "fill_sample_ts": None,
+                })
+                continue
+            window_end = _load_window_end(conn, d["window_slug"])
+            cancel_at = (window_end - cancel_buffer_s) if window_end else None
+            filled, idx, ts = _walk_samples_for_fill(
+                conn, d["window_slug"], d["preview_side"], rest,
+                d["decision_ts"], cancel_at,
+            )
+            results.append({
+                **d, "rest_price": rest, "filled": filled,
+                "fill_sample_index": idx if filled else None,
+                "fill_sample_ts": ts,
+            })
+
+    n_eligible = n_total - n_no_pmc
+    n_filled = sum(1 for r in results if r["filled"])
+    fill_rate = (n_filled / n_eligible) if n_eligible > 0 else 0.0
+    fill_indices = [r["fill_sample_index"] for r in results if r["filled"]]
+    median_fill_idx = sorted(fill_indices)[len(fill_indices) // 2] if fill_indices else None
+
+    # Calibration on the would-have-filled cohort with known outcomes.
+    n_bins = int(round((DEFAULT_BIN_HI - DEFAULT_BIN_LO) / bin_width))
+    bins: list[dict] = [
+        {"lo": DEFAULT_BIN_LO + i * bin_width, "hi": DEFAULT_BIN_LO + (i + 1) * bin_width,
+         "n": 0, "sum_p": 0.0, "sum_hit": 0}
+        for i in range(n_bins)
+    ]
+    for r in results:
+        if not r["filled"] or r["outcome"] not in {"up", "down"}:
+            continue
+        p = r["model_p_up"]
+        b = _calibration_bin(p, bin_width, DEFAULT_BIN_LO, DEFAULT_BIN_HI)
+        if b is None:
+            continue
+        if p >= 0.5:
+            p_pred = p
+            hit = 1 if r["outcome"] == "up" else 0
+        else:
+            p_pred = 1.0 - p
+            hit = 1 if r["outcome"] == "down" else 0
+        bins[b]["n"] += 1
+        bins[b]["sum_p"] += p_pred
+        bins[b]["sum_hit"] += hit
+
+    return {
+        "db_path": db_path,
+        "offset_ticks": offset_ticks,
+        "cancel_buffer_s": cancel_buffer_s,
+        "n_total_decisions": n_total,
+        "n_eligible": n_eligible,
+        "n_no_pmc": n_no_pmc,
+        "n_filled": n_filled,
+        "fill_rate": fill_rate,
+        "median_fill_sample_index": median_fill_idx,
+        "calibration_bins": bins,
+    }
+
+
+def _format_report(stats: dict) -> str:
+    lines: list[str] = []
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    lines.append(f"# Post-only paper replay — {now}")
+    lines.append("")
+    lines.append(f"- DB: `{stats['db_path']}`")
+    lines.append(f"- offset_ticks: `{stats['offset_ticks']}`")
+    lines.append(f"- cancel_buffer_s: `{stats['cancel_buffer_s']}`")
+    lines.append("")
+    lines.append("## Fill statistics")
+    lines.append("")
+    lines.append(f"- Total decisions with bids JSON: **{stats['n_total_decisions']}**")
+    lines.append(f"- Eligible (pmc computable): **{stats['n_eligible']}** "
+                 f"(skipped {stats['n_no_pmc']} for missing opp bid)")
+    lines.append(f"- Would-have-filled: **{stats['n_filled']}**")
+    lines.append(f"- Fill rate: **{stats['fill_rate'] * 100:.1f}%**")
+    if stats["median_fill_sample_index"] is not None:
+        idx = stats["median_fill_sample_index"]
+        lines.append(f"- Median post-decision sample-index at fill: **{idx}** "
+                     f"(~{idx * 30}s after decision time)")
+    lines.append("")
+    lines.append("Note: book samples are at 30-second cadence; reported fill rate "
+                 "is a LOWER BOUND. Live data with sub-second granularity may show "
+                 "a higher fill rate.")
+    lines.append("")
+    lines.append("## Calibration (would-have-filled cohort only)")
+    lines.append("")
+    lines.append("| bin | n | mean p_pred | hit rate | gap |")
+    lines.append("|---|---:|---:|---:|---:|")
+    for b in stats["calibration_bins"]:
+        if b["n"] == 0:
+            continue
+        mean_p = b["sum_p"] / b["n"]
+        hit_rate = b["sum_hit"] / b["n"]
+        gap = hit_rate - mean_p
+        lines.append(
+            f"| {b['lo']:.2f}-{b['hi']:.2f} | {b['n']} | {mean_p:.3f} | "
+            f"{hit_rate:.3f} | {gap:+.3f} |"
+        )
+    lines.append("")
+    lines.append("## Acceptance check")
+    lines.append("")
+    rate = stats["fill_rate"]
+    if rate < 0.15:
+        lines.append(f"- :warning: Fill rate **{rate*100:.1f}%** is below 15% — "
+                     "offset may be too deep. Consider lowering "
+                     "POST_ONLY_REST_OFFSET_TICKS.")
+    elif rate > 0.80:
+        lines.append(f"- :warning: Fill rate **{rate*100:.1f}%** is above 80% — "
+                     "the rest price is likely crossing immediately in live "
+                     "(would-reject post-only). Consider raising offset.")
+    else:
+        lines.append(f"- Fill rate **{rate*100:.1f}%** is in the plausible 15-80% band.")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", default=PAPER_DB_PATH, help="Paper DB path")
+    parser.add_argument("--offset-ticks", type=int, default=POST_ONLY_REST_OFFSET_TICKS)
+    parser.add_argument("--cancel-buffer-s", type=float,
+                        default=POST_ONLY_CANCEL_AT_T_REMAINING_S)
+    parser.add_argument("--out", default="scripts/_post_only_replay.md",
+                        help="Output markdown path")
+    args = parser.parse_args()
+
+    if not Path(args.db).exists():
+        print(f"DB not found: {args.db}")
+        return 1
+
+    stats = replay(args.db, args.offset_ticks, args.cancel_buffer_s)
+    report = _format_report(stats)
+    Path(args.out).write_text(report, encoding="utf-8")
+    print(f"Wrote {args.out}")
+    print(f"  n_eligible={stats['n_eligible']}  "
+          f"n_filled={stats['n_filled']}  "
+          f"fill_rate={stats['fill_rate']*100:.1f}%")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,5 +26,6 @@ for _key in (
     "POST_ONLY_REST_OFFSET_TICKS",
     "POST_ONLY_CANCEL_AT_T_REMAINING_S",
     "POST_ONLY_EXPIRY_SAFETY_BUFFER_S",
+    "POLYMARKET_MIN_EXPIRATION_BUFFER_S",
 ):
     os.environ.pop(_key, None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,5 +22,9 @@ for _key in (
     "MAX_BOOK_AGE_S",
     "SIGNAL_CUSHION_TICKS",
     "IOC_BUFFER_TICKS",
+    "ENTRY_MODE",
+    "POST_ONLY_REST_OFFSET_TICKS",
+    "POST_ONLY_CANCEL_AT_T_REMAINING_S",
+    "POST_ONLY_EXPIRY_SAFETY_BUFFER_S",
 ):
     os.environ.pop(_key, None)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1934,10 +1934,20 @@ async def test_bot_dispatches_to_post_only_when_entry_mode_set(tmp_path: Path, m
 
     post_only_mock.assert_called_once()
     fak_mock.assert_not_called()
-    # Dispatch passed offset_ticks + expiration
+    # Dispatch passed offset_ticks + expiration. Expiration is the max of
+    # (window.end_time - POST_ONLY_EXPIRY_SAFETY_BUFFER_S) and the server's
+    # required minimum (now + POLYMARKET_MIN_EXPIRATION_BUFFER_S). With
+    # the default buffers (60 and 65) and the helper's end_offset=180,
+    # both candidates are <= now + 120 so the floor wins.
     kwargs = post_only_mock.call_args.kwargs
     assert kwargs["offset_ticks"] == 2  # default POST_ONLY_REST_OFFSET_TICKS
-    assert kwargs["expiration"] == int(window.end_time - 30.0)
+    expected_target = int(window.end_time - 60.0)
+    expected_floor = int(time.time()) + 65
+    expected_min = max(expected_target, expected_floor)
+    # Allow a 1s slack — wall clock may have ticked between bot call and assertion.
+    assert abs(kwargs["expiration"] - expected_min) <= 1, (
+        f"expected ~{expected_min}, got {kwargs['expiration']}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1858,3 +1858,228 @@ async def test_phase5_new_window_resets_cadence(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(bot_module.time, "time", lambda: t0 + 320.0)
     await bot._on_book_update(window_b, "up")
     assert len(get_book_samples(str(db_path), "win-b")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Post-only / maker-side entries (2026-05-15)
+# ---------------------------------------------------------------------------
+
+
+def _post_only_window(slug="btc-updown-5m-po", end_offset=180.0):
+    return Window(
+        condition_id="po-cond",
+        question="BTC Up or Down",
+        up_token_id="tok_up",
+        down_token_id="tok_down",
+        end_time=time.time() + end_offset,
+        slug=slug,
+        price_to_beat=84198.0,
+        up_ask=0.55,
+        down_ask=0.45,
+        up_bids=[{"price": 0.50, "size": 100.0}],
+        down_bids=[{"price": 0.45, "size": 100.0}],
+    )
+
+
+@pytest.mark.asyncio
+async def test_bot_dispatches_to_post_only_when_entry_mode_set(tmp_path: Path, monkeypatch):
+    """ENTRY_MODE=post_only routes the live branch to execute_live_trade_post_only,
+    NOT to execute_live_trade."""
+    import polypocket.bot as bot_module
+    from polypocket.bot import Bot
+
+    db_path = tmp_path / "bot.db"
+    init_db(str(db_path))
+
+    monkeypatch.setattr(bot_module, "TRADING_MODE", "live")
+    monkeypatch.setattr(bot_module, "ENTRY_MODE", "post_only")
+
+    fak_mock = Mock(return_value=TradeResult(success=False, error="should-not-fire"))
+    post_only_mock = Mock(return_value=TradeResult(success=True, trade_id=1, pnl=None))
+    monkeypatch.setattr(bot_module, "execute_live_trade", fak_mock)
+    monkeypatch.setattr(bot_module, "execute_live_trade_post_only", post_only_mock)
+
+    client = Mock()
+    client.get_usdc_balance.return_value = 100.0
+
+    bot = Bot(db_path=str(db_path), live_order_client=client)
+    bot.binance.latest_price = 84350.0
+    bot.signal_engine.evaluate = Mock(return_value=Signal(
+        side="up", model_p_up=0.75, market_price=0.55, edge=0.20,
+        up_edge=0.20, down_edge=-0.20, signal_reference_price=0.55,
+    ))
+    bot.risk.check = lambda: (True, "")
+
+    window = _post_only_window()
+    window.book_updated_at = time.monotonic()
+
+    # Have the mocked dispatch write the placed row, mirroring what the
+    # real execute_live_trade_post_only would do — otherwise the bot's
+    # post-dispatch find_trade_by_window_slug returns None and the
+    # _open_trade fall-through uses the dispatch-call's intended_size.
+    def _fake_post_only_dispatch(**kwargs):
+        log_trade(
+            db_path=str(db_path),
+            window_slug=kwargs["window_slug"],
+            side="up", entry_price=0.53, size=kwargs["intended_size"], fees=0.0,
+            model_p_up=0.75, market_p_up=0.55, edge=0.20,
+            outcome=None, pnl=None, status="placed",
+            entry_mode="post_only", rest_price=0.53,
+        )
+        return TradeResult(success=True, trade_id=1, pnl=None)
+
+    post_only_mock.side_effect = _fake_post_only_dispatch
+
+    await bot._on_book_update(window, "up")
+
+    post_only_mock.assert_called_once()
+    fak_mock.assert_not_called()
+    # Dispatch passed offset_ticks + expiration
+    kwargs = post_only_mock.call_args.kwargs
+    assert kwargs["offset_ticks"] == 2  # default POST_ONLY_REST_OFFSET_TICKS
+    assert kwargs["expiration"] == int(window.end_time - 30.0)
+
+
+@pytest.mark.asyncio
+async def test_bot_cancels_post_only_at_t_remaining_threshold(tmp_path: Path, monkeypatch):
+    """When a resting post-only is open and t_remaining <= threshold,
+    the bot tick fires cancel_post_only_order with trigger='window-close'."""
+    import polypocket.bot as bot_module
+    from polypocket.bot import Bot
+
+    db_path = tmp_path / "bot.db"
+    init_db(str(db_path))
+
+    monkeypatch.setattr(bot_module, "TRADING_MODE", "live")
+
+    # Pre-populate a placed trade in the DB.
+    trade_id = log_trade(
+        db_path=str(db_path),
+        window_slug="btc-updown-5m-po-cancel",
+        side="up", entry_price=0.53, size=10.0, fees=0.0,
+        model_p_up=0.75, market_p_up=0.55, edge=0.20,
+        outcome=None, pnl=None, status="placed",
+        entry_mode="post_only", rest_price=0.53,
+    )
+    from polypocket.ledger import update_trade
+    update_trade(str(db_path), trade_id, outcome=None, pnl=None, status="placed",
+                 external_order_id="po-1")
+
+    cancel_mock = Mock(return_value="rejected")
+    monkeypatch.setattr(bot_module, "cancel_post_only_order", cancel_mock)
+
+    bot = Bot(db_path=str(db_path), live_order_client=Mock())
+    bot.binance.latest_price = 84000.0
+    bot.signal_engine.evaluate = Mock(return_value=None)
+    bot.risk.check = lambda: (True, "")
+    bot._open_trade = {
+        "trade_id": trade_id, "side": "up", "entry_price": 0.53, "size": 10.0,
+        "mode": "live", "status": "placed", "external_order_id": "po-1",
+    }
+    bot._current_window = _post_only_window(slug="btc-updown-5m-po-cancel", end_offset=10.0)
+    bot._current_window_id = bot._current_window.condition_id
+    bot._window_traded = True  # block signal eval re-fire on this same tick
+
+    # t_remaining = 10s on the window — under the 30s threshold.
+    await bot._on_book_update(bot._current_window, "up")
+
+    cancel_mock.assert_called_once()
+    _, _, _, kwargs_or_trigger = cancel_mock.call_args.args + (None,) * (4 - len(cancel_mock.call_args.args))
+    assert cancel_mock.call_args.kwargs.get("trigger") == "window-close"
+    # Returned 'rejected' → open_trade dropped, status set.
+    assert bot._open_trade is None
+    assert bot.stats["execution_status"] == "post-only-no-fill"
+
+
+@pytest.mark.asyncio
+async def test_bot_post_only_cancel_promotes_partial_fill(tmp_path: Path, monkeypatch):
+    """cancel_post_only_order returns 'open' (partial fill detected) → bot
+    adopts the partial fill as the open position."""
+    import polypocket.bot as bot_module
+    from polypocket.bot import Bot
+    from polypocket.ledger import update_trade
+
+    db_path = tmp_path / "bot.db"
+    init_db(str(db_path))
+
+    monkeypatch.setattr(bot_module, "TRADING_MODE", "live")
+
+    trade_id = log_trade(
+        db_path=str(db_path),
+        window_slug="btc-updown-5m-po-partial",
+        side="up", entry_price=0.53, size=10.0, fees=0.0,
+        model_p_up=0.75, market_p_up=0.55, edge=0.20,
+        outcome=None, pnl=None, status="placed",
+        entry_mode="post_only", rest_price=0.53,
+    )
+    update_trade(str(db_path), trade_id, outcome=None, pnl=None, status="placed",
+                 external_order_id="po-2")
+
+    # Simulate cancel-reconcile promoting to open with size=4 partial.
+    def fake_cancel(db_path_arg, trade_row, client, trigger):
+        update_trade(db_path_arg, trade_row["id"], outcome=None, pnl=None,
+                     status="open", size=4.0, entry_price=0.53)
+        return "open"
+
+    monkeypatch.setattr(bot_module, "cancel_post_only_order", fake_cancel)
+
+    bot = Bot(db_path=str(db_path), live_order_client=Mock())
+    bot.binance.latest_price = 84000.0
+    bot.signal_engine.evaluate = Mock(return_value=None)
+    bot.risk.check = lambda: (True, "")
+    bot._open_trade = {
+        "trade_id": trade_id, "side": "up", "entry_price": 0.53, "size": 10.0,
+        "mode": "live", "status": "placed", "external_order_id": "po-2",
+    }
+    bot._current_window = _post_only_window(slug="btc-updown-5m-po-partial", end_offset=10.0)
+    bot._current_window_id = bot._current_window.condition_id
+    bot._window_traded = True
+
+    await bot._on_book_update(bot._current_window, "up")
+
+    assert bot._open_trade is not None
+    assert bot._open_trade["status"] == "open"
+    assert bot._open_trade["size"] == pytest.approx(4.0)
+
+
+@pytest.mark.asyncio
+async def test_paper_path_unchanged_with_post_only_config_set(tmp_path: Path, monkeypatch):
+    """Bit-identity guarantee: ENTRY_MODE=post_only in paper mode must NOT
+    enter any post-only code path. Paper continues to call execute_paper_trade
+    with no submit_post_only call on any client mock."""
+    import polypocket.bot as bot_module
+    from polypocket.bot import Bot
+
+    monkeypatch.setattr(bot_module, "TRADING_MODE", "paper")
+    monkeypatch.setattr(bot_module, "ENTRY_MODE", "post_only")  # set but irrelevant
+
+    db_path = tmp_path / "bot.db"
+    init_db(str(db_path))
+
+    paper_mock = Mock(return_value=TradeResult(success=True, trade_id=1, pnl=None))
+    post_only_mock = Mock(return_value=TradeResult(success=False, error="should-not-fire"))
+    monkeypatch.setattr(bot_module, "execute_paper_trade", paper_mock)
+    monkeypatch.setattr(bot_module, "execute_live_trade_post_only", post_only_mock)
+
+    bot = Bot(db_path=str(db_path))
+    bot.binance.latest_price = 84350.0
+    bot.signal_engine.evaluate = lambda **kwargs: Signal(
+        side="up", model_p_up=0.75, market_price=0.55, edge=0.20,
+        up_edge=0.20, down_edge=-0.20, signal_reference_price=0.55,
+    )
+    bot.risk.check = lambda: (True, "")
+
+    window = _post_only_window(slug="btc-updown-5m-paper-po")
+    await bot._on_book_update(window, "up")
+
+    paper_mock.assert_called_once()
+    post_only_mock.assert_not_called()
+
+
+def test_recoverable_statuses_includes_placed_in_live(monkeypatch):
+    """Structural check: live-mode recovery sweeps over 'placed' so a
+    resting post-only order from a previous run gets cancel-and-reconciled.
+    Verified indirectly via the source — string match on the placed-add line."""
+    import inspect, polypocket.bot as bot_module
+    src = inspect.getsource(bot_module._on_book_update if False else bot_module.Bot._on_book_update)
+    assert 'recoverable_statuses.add("placed")' in src

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1039,6 +1039,9 @@ async def test_live_mode_threads_up_token_id(tmp_path: Path, monkeypatch):
         def get_usdc_balance(self):
             return 1000.0
 
+        def get_order_book(self, token_id):
+            return {}
+
     db_path = tmp_path / "live.db"
     init_db(str(db_path))
     client = CapturingClient()
@@ -1114,6 +1117,9 @@ class _CapturingClient:
 
     def get_usdc_balance(self):
         return 1000.0
+
+    def get_order_book(self, token_id):
+        return {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -8,10 +8,13 @@ from unittest.mock import MagicMock
 
 from polypocket.executor import (
     FillResult,
+    PlaceResult,
     SettlementInfo,
     TradeResult,
-    execute_paper_trade,
+    cancel_post_only_order,
     execute_live_trade,
+    execute_live_trade_post_only,
+    execute_paper_trade,
     reconcile_recovered_trade,
     settle_live_trade,
 )
@@ -1258,3 +1261,228 @@ def test_execute_paper_trade_persists_signal_reference_price(tmp_path):
     row = find_trade_by_window_slug(db, "w1")
     assert row["signal_reference_price"] == pytest.approx(0.60, abs=1e-9)
     assert row["signal_reference_source"] == "live"
+
+
+# ---------------------------------------------------------------------------
+# Post-only / maker-side entries (2026-05-15)
+# ---------------------------------------------------------------------------
+
+
+def _down_bids(price, size=100.0):
+    return [{"price": price, "size": size}]
+
+
+def test_execute_live_trade_post_only_placed_happy_path():
+    db_path = make_db()
+    signal = _sample_signal()
+    signal = Signal(
+        side=signal.side, model_p_up=signal.model_p_up,
+        market_price=signal.market_price, edge=signal.edge,
+        up_edge=signal.up_edge, down_edge=signal.down_edge,
+        signal_reference_price=0.55,
+    )
+    client = MagicMock()
+    client.get_usdc_balance.return_value = 100.0
+    client.submit_post_only.return_value = PlaceResult(
+        status="placed", order_id="po-abc", error=None,
+    )
+    result = execute_live_trade_post_only(
+        db_path=db_path, signal=signal, intended_size=10.0,
+        window_slug="w-po-1", token_id="T-UP", condition_id="C",
+        client=client,
+        up_bids=[], down_bids=_down_bids(0.45),
+        offset_ticks=2, expiration=1_700_000_000,
+    )
+    assert result.success
+    row = find_trade_by_window_slug(db_path, "w-po-1")
+    assert row["status"] == "placed"
+    assert row["entry_mode"] == "post_only"
+    # rest_price = 1 - 0.45 - 0.02 = 0.53
+    assert row["rest_price"] == pytest.approx(0.53)
+    assert row["entry_price"] == pytest.approx(0.53)
+    assert row["external_order_id"] == "po-abc"
+    events = _order_events(db_path, row["id"])
+    assert {e["event_type"] for e in events} >= {"place", "ack"}
+    os.unlink(db_path)
+
+
+def test_execute_live_trade_post_only_no_opp_bid_skips():
+    db_path = make_db()
+    signal = _sample_signal()
+    client = MagicMock()
+    client.get_usdc_balance.return_value = 100.0
+    result = execute_live_trade_post_only(
+        db_path=db_path, signal=signal, intended_size=10.0,
+        window_slug="w-po-2", token_id="T-UP", condition_id="C",
+        client=client,
+        up_bids=[], down_bids=[],
+        offset_ticks=2, expiration=1_700_000_000,
+    )
+    assert result.success is False
+    assert result.error == "no-pair-merge-counterparty"
+    # No row written.
+    assert find_trade_by_window_slug(db_path, "w-po-2") is None
+    client.submit_post_only.assert_not_called()
+    os.unlink(db_path)
+
+
+def test_execute_live_trade_post_only_insufficient_balance():
+    db_path = make_db()
+    signal = _sample_signal()
+    client = MagicMock()
+    client.get_usdc_balance.return_value = 1.0  # below need
+    result = execute_live_trade_post_only(
+        db_path=db_path, signal=signal, intended_size=10.0,
+        window_slug="w-po-3", token_id="T-UP", condition_id="C",
+        client=client,
+        up_bids=[], down_bids=_down_bids(0.45),
+        offset_ticks=2, expiration=1_700_000_000,
+    )
+    assert result.success is False
+    assert result.error == "insufficient-balance"
+    assert find_trade_by_window_slug(db_path, "w-po-3") is None
+    client.submit_post_only.assert_not_called()
+    os.unlink(db_path)
+
+
+def test_execute_live_trade_post_only_would_cross_rejected():
+    db_path = make_db()
+    signal = _sample_signal()
+    client = MagicMock()
+    client.get_usdc_balance.return_value = 100.0
+    client.submit_post_only.return_value = PlaceResult(
+        status="rejected", order_id="po-xc", error="post-only-would-cross",
+    )
+    result = execute_live_trade_post_only(
+        db_path=db_path, signal=signal, intended_size=10.0,
+        window_slug="w-po-4", token_id="T-UP", condition_id="C",
+        client=client,
+        up_bids=[], down_bids=_down_bids(0.45),
+        offset_ticks=2, expiration=1_700_000_000,
+    )
+    assert result.success is False
+    row = find_trade_by_window_slug(db_path, "w-po-4")
+    assert row["status"] == "rejected"
+    assert row["error"] == "post-only-would-cross"
+    assert row["external_order_id"] == "po-xc"
+    events = _order_events(db_path, row["id"])
+    assert {e["event_type"] for e in events} == {"place", "ack", "reject"}
+    os.unlink(db_path)
+
+
+def test_cancel_post_only_order_full_fill():
+    db_path = make_db()
+    # Pre-populate a placed row.
+    trade_id = persist_trade(
+        db_path=db_path, window_slug="w-po-5", side="up", entry_price=0.54,
+        size=10.0, fees=0.0, model_p_up=0.72, market_p_up=0.55, edge=0.18,
+        outcome=None, pnl=None, status="placed",
+        entry_mode="post_only", rest_price=0.54,
+    )
+    update_trade(db_path, trade_id, outcome=None, pnl=None, status="placed",
+                 external_order_id="po-1")
+
+    client = MagicMock()
+    client.cancel_order.return_value = True
+    client.get_settlement_info.return_value = SettlementInfo(
+        shares_held=10.0, cost_usdc=5.40,
+    )
+    trade_row = find_trade_by_window_slug(db_path, "w-po-5")
+    final = cancel_post_only_order(db_path, trade_row, client, trigger="window-close")
+
+    assert final == "open"
+    row = find_trade_by_window_slug(db_path, "w-po-5")
+    assert row["status"] == "open"
+    assert row["size"] == pytest.approx(10.0)
+    assert row["entry_price"] == pytest.approx(0.54)
+    events = _order_events(db_path, trade_id)
+    event_types = [e["event_type"] for e in events]
+    assert event_types.count("cancel") == 2  # request + ack phases
+    assert "fill" in event_types
+    os.unlink(db_path)
+
+
+def test_cancel_post_only_order_zero_fill():
+    db_path = make_db()
+    trade_id = persist_trade(
+        db_path=db_path, window_slug="w-po-6", side="up", entry_price=0.54,
+        size=10.0, fees=0.0, model_p_up=0.72, market_p_up=0.55, edge=0.18,
+        outcome=None, pnl=None, status="placed",
+        entry_mode="post_only", rest_price=0.54,
+    )
+    update_trade(db_path, trade_id, outcome=None, pnl=None, status="placed",
+                 external_order_id="po-2")
+
+    client = MagicMock()
+    client.cancel_order.return_value = True
+    client.get_settlement_info.return_value = SettlementInfo(
+        shares_held=0.0, cost_usdc=0.0,
+    )
+    trade_row = find_trade_by_window_slug(db_path, "w-po-6")
+    final = cancel_post_only_order(db_path, trade_row, client, trigger="window-close")
+
+    assert final == "rejected"
+    row = find_trade_by_window_slug(db_path, "w-po-6")
+    assert row["status"] == "rejected"
+    assert row["error"] == "post-only-no-fill"
+    os.unlink(db_path)
+
+
+def test_cancel_post_only_order_cancel_race_partial_fill():
+    """Integration-style: cancel returns False (race lost) but
+    get_settlement_info shows partial shares_held. CLOB state is authoritative;
+    row promotes to 'open' with the realized partial size."""
+    db_path = make_db()
+    trade_id = persist_trade(
+        db_path=db_path, window_slug="w-po-7", side="up", entry_price=0.54,
+        size=10.0, fees=0.0, model_p_up=0.72, market_p_up=0.55, edge=0.18,
+        outcome=None, pnl=None, status="placed",
+        entry_mode="post_only", rest_price=0.54,
+    )
+    update_trade(db_path, trade_id, outcome=None, pnl=None, status="placed",
+                 external_order_id="po-3", error="ignored-stale")
+
+    client = MagicMock()
+    client.cancel_order.return_value = False  # cancel lost the race
+    client.get_settlement_info.return_value = SettlementInfo(
+        shares_held=4.0, cost_usdc=2.16,
+    )
+    trade_row = find_trade_by_window_slug(db_path, "w-po-7")
+    final = cancel_post_only_order(db_path, trade_row, client, trigger="window-close")
+
+    assert final == "open"
+    row = find_trade_by_window_slug(db_path, "w-po-7")
+    assert row["status"] == "open"
+    assert row["size"] == pytest.approx(4.0)
+    assert row["entry_price"] == pytest.approx(0.54)
+    # Stale error cleared on promote.
+    assert row["error"] is None
+    os.unlink(db_path)
+
+
+def test_reconcile_recovered_trade_live_status_triggers_cancel():
+    """A recovered post-only trade with CLOB status='live' must be
+    cancelled-and-reconciled inline by the recovery path."""
+    db_path = make_db()
+    trade_id = persist_trade(
+        db_path=db_path, window_slug="w-po-rec", side="up", entry_price=0.54,
+        size=10.0, fees=0.0, model_p_up=0.72, market_p_up=0.55, edge=0.18,
+        outcome=None, pnl=None, status="placed",
+        entry_mode="post_only", rest_price=0.54,
+    )
+    update_trade(db_path, trade_id, outcome=None, pnl=None, status="placed",
+                 external_order_id="po-live")
+
+    client = MagicMock()
+    client.get_order_status.return_value = {"status": "live"}
+    # The cancel-reconcile path is exercised: zero-fill cleanup.
+    client.cancel_order.return_value = True
+    client.get_settlement_info.return_value = SettlementInfo(0.0, 0.0)
+
+    trade_row = find_trade_by_window_slug(db_path, "w-po-rec")
+    final = reconcile_recovered_trade(db_path, trade_row, client)
+
+    assert final == "rejected"
+    client.cancel_order.assert_called_once_with("po-live")
+    client.get_settlement_info.assert_called_once_with("po-live")
+    os.unlink(db_path)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -217,6 +217,9 @@ class RecordingLiveOrderClient:
     def get_usdc_balance(self):
         return self._balance
 
+    def get_order_book(self, token_id):
+        return {}
+
 
 class RejectingLiveOrderClient:
     def __init__(self, balance=1000.0, error="no match"):
@@ -240,6 +243,9 @@ class RejectingLiveOrderClient:
 
     def get_usdc_balance(self):
         return self._balance
+
+    def get_order_book(self, token_id):
+        return {}
 
 
 def test_live_trade_threads_args_to_client():
@@ -463,6 +469,9 @@ class SettlingLiveOrderClient:
         self.settlement_lookups.append(order_id)
         return self._settlements[order_id]
 
+    def get_order_book(self, token_id):
+        return {}
+
 
 def _seed_open_live_trade(db_path, window_slug, side, order_id):
     trade_id = persist_trade(
@@ -579,6 +588,8 @@ def test_live_trade_client_error_marks_trade_rejected():
                               avg_price=None, error="network: timeout")
         def get_usdc_balance(self):
             return 1000.0
+        def get_order_book(self, token_id):
+            return {}
 
     db_path = make_db()
     signal = Signal(side="up", model_p_up=0.72, market_price=0.51,
@@ -991,6 +1002,121 @@ def test_execute_live_trade_submit_payload_book_age_is_none_when_no_timestamp():
     import json
     submit_payload = json.loads(events[0]["payload_json"])
     assert submit_payload["book_age_s_monotonic"] is None
+    os.unlink(db_path)
+
+
+class _BookSnapshotClient(RecordingLiveOrderClient):
+    """RecordingLiveOrderClient + a per-token book response for ack-time snapshot."""
+    def __init__(self, books: dict[str, dict] | None = None, raise_on: str | None = None):
+        super().__init__()
+        self._books = books or {}
+        self._raise_on = raise_on
+        self.book_calls: list[str] = []
+
+    def get_order_book(self, token_id):
+        self.book_calls.append(token_id)
+        if self._raise_on and token_id == self._raise_on:
+            raise RuntimeError("simulated /book outage")
+        return self._books.get(token_id, {})
+
+
+def test_execute_live_trade_ack_payload_carries_book_at_ack():
+    """Ack-time book snapshot: both sides fetched, compressed to top-3, embedded
+    under `book_at_ack` with side-aware up/down keys."""
+    db_path = make_db()
+    up_book = {
+        "bids": [
+            {"price": "0.56", "size": "100"},
+            {"price": "0.55", "size": "200"},
+            {"price": "0.54", "size": "300"},
+            {"price": "0.53", "size": "400"},
+        ],
+        "asks": [{"price": "0.58", "size": "150"}],
+        "timestamp": "1778900000",
+        "hash": "abc",
+    }
+    down_book = {
+        "bids": [{"price": "0.41", "size": "120"}],
+        "asks": [{"price": "0.43", "size": "180"}],
+        "timestamp": "1778900001",
+        "hash": "def",
+    }
+    client = _BookSnapshotClient(books={"TKN-UP": up_book, "TKN-DOWN": down_book})
+
+    result = execute_live_trade(
+        db_path=db_path, signal=_sample_signal(),
+        entry_price=0.55, size=5.0, window_slug="w-book-ack",
+        token_id="TKN-UP", condition_id="C", client=client,
+        limit_price=0.63, opposite_token_id="TKN-DOWN",
+    )
+    assert result.success is True
+    assert client.book_calls == ["TKN-UP", "TKN-DOWN"]
+
+    events = _order_events(db_path, result.trade_id)
+    import json
+    ack_payload = json.loads(events[1]["payload_json"])
+    assert "book_at_ack" in ack_payload
+    assert ack_payload["book_at_ack"]["up_book"]["bids"] == up_book["bids"][:3]
+    assert ack_payload["book_at_ack"]["up_book"]["asks"] == up_book["asks"]
+    assert ack_payload["book_at_ack"]["up_book"]["hash"] == "abc"
+    assert ack_payload["book_at_ack"]["down_book"]["bids"] == down_book["bids"]
+    assert ack_payload["book_at_ack"]["down_book"]["asks"] == down_book["asks"]
+    assert ack_payload["book_fetched_at_wall"] is not None
+    os.unlink(db_path)
+
+
+def test_execute_live_trade_ack_payload_omits_book_when_fetch_raises():
+    """Book fetch is best-effort: a raising get_order_book must not break the
+    trade and must leave `book_at_ack` absent from the ack payload."""
+    db_path = make_db()
+    client = _BookSnapshotClient(raise_on="TKN-UP")
+
+    result = execute_live_trade(
+        db_path=db_path, signal=_sample_signal(),
+        entry_price=0.55, size=5.0, window_slug="w-book-fail",
+        token_id="TKN-UP", condition_id="C", client=client,
+        limit_price=0.63, opposite_token_id="TKN-DOWN",
+    )
+    assert result.success is True
+
+    events = _order_events(db_path, result.trade_id)
+    import json
+    ack_payload = json.loads(events[1]["payload_json"])
+    assert "book_at_ack" not in ack_payload
+    assert "book_fetched_at_wall" not in ack_payload
+    # Existing ack fields still present.
+    assert ack_payload["status"] == "filled"
+    os.unlink(db_path)
+
+
+def test_execute_live_trade_skips_opposite_book_when_token_id_absent():
+    """Backwards compatibility: callers that don't pass opposite_token_id still
+    work — only the side's own book is fetched, and book_at_ack reflects that."""
+    db_path = make_db()
+    side_book = {
+        "bids": [{"price": "0.56", "size": "100"}],
+        "asks": [{"price": "0.58", "size": "150"}],
+        "timestamp": "1778900000",
+    }
+    client = _BookSnapshotClient(books={"TKN-UP": side_book})
+
+    result = execute_live_trade(
+        db_path=db_path, signal=_sample_signal(),
+        entry_price=0.55, size=5.0, window_slug="w-no-opp",
+        token_id="TKN-UP", condition_id="C", client=client,
+        limit_price=0.63,
+        # opposite_token_id default → None: opposite book is empty
+    )
+    assert result.success is True
+    assert client.book_calls == ["TKN-UP"]
+
+    events = _order_events(db_path, result.trade_id)
+    import json
+    ack_payload = json.loads(events[1]["payload_json"])
+    assert ack_payload["book_at_ack"]["up_book"]["bids"] == side_book["bids"]
+    # Opposite book is present-but-empty (no token to fetch).
+    assert ack_payload["book_at_ack"]["down_book"]["bids"] == []
+    assert ack_payload["book_at_ack"]["down_book"]["asks"] == []
     os.unlink(db_path)
 
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1306,6 +1306,68 @@ def test_execute_live_trade_post_only_placed_happy_path():
     os.unlink(db_path)
 
 
+def test_execute_live_trade_post_only_records_actual_placed_size():
+    """SDK wrapper's tick-safe quantization may shift size by ±6; the trade
+    row must reflect the actually-placed size (carried back via
+    PlaceResult.placed_size), not the caller's intended_size."""
+    db_path = make_db()
+    signal = _sample_signal()
+    signal = Signal(
+        side=signal.side, model_p_up=signal.model_p_up,
+        market_price=signal.market_price, edge=signal.edge,
+        up_edge=signal.up_edge, down_edge=signal.down_edge,
+        signal_reference_price=0.55,
+    )
+    client = MagicMock()
+    client.get_usdc_balance.return_value = 100.0
+    # Caller intended 10.5 shares; SDK quantized to 11 (or whatever) and
+    # surfaces the true value via placed_size.
+    client.submit_post_only.return_value = PlaceResult(
+        status="placed", order_id="po-quant", error=None, placed_size=11.0,
+    )
+    result = execute_live_trade_post_only(
+        db_path=db_path, signal=signal, intended_size=10.5,
+        window_slug="w-po-quant", token_id="T-UP", condition_id="C",
+        client=client,
+        up_bids=[], down_bids=_down_bids(0.45),
+        offset_ticks=2, expiration=1_700_000_000,
+    )
+    assert result.success
+    row = find_trade_by_window_slug(db_path, "w-po-quant")
+    assert row["status"] == "placed"
+    assert row["size"] == pytest.approx(11.0)
+    os.unlink(db_path)
+
+
+def test_execute_live_trade_post_only_falls_back_when_placed_size_none():
+    """Backwards compatibility: a PlaceResult without placed_size (e.g.
+    older test doubles) leaves the trade row at intended_size."""
+    db_path = make_db()
+    signal = _sample_signal()
+    signal = Signal(
+        side=signal.side, model_p_up=signal.model_p_up,
+        market_price=signal.market_price, edge=signal.edge,
+        up_edge=signal.up_edge, down_edge=signal.down_edge,
+        signal_reference_price=0.55,
+    )
+    client = MagicMock()
+    client.get_usdc_balance.return_value = 100.0
+    client.submit_post_only.return_value = PlaceResult(
+        status="placed", order_id="po-fb", error=None,  # placed_size omitted
+    )
+    result = execute_live_trade_post_only(
+        db_path=db_path, signal=signal, intended_size=7.0,
+        window_slug="w-po-fb", token_id="T-UP", condition_id="C",
+        client=client,
+        up_bids=[], down_bids=_down_bids(0.45),
+        offset_ticks=2, expiration=1_700_000_000,
+    )
+    assert result.success
+    row = find_trade_by_window_slug(db_path, "w-po-fb")
+    assert row["size"] == pytest.approx(7.0)
+    os.unlink(db_path)
+
+
 def test_execute_live_trade_post_only_no_opp_bid_skips():
     db_path = make_db()
     signal = _sample_signal()

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -14,6 +14,7 @@ from polypocket.ledger import (
     get_session_stats,
     find_duplicate_window_slugs,
     find_trade_by_window_slug,
+    find_unsettled_trades,
     get_snapshots_for_window,
     init_db,
     log_snapshot,
@@ -613,3 +614,30 @@ def test_init_db_signal_reference_columns_are_idempotent(tmp_path):
         col_count = sum(1 for row in c.execute("PRAGMA table_info(trades)").fetchall()
                         if row[1] == "signal_reference_price")
     assert col_count == 1
+
+
+def test_find_unsettled_trades_includes_placed():
+    """A resting post-only order (status='placed') from a previous run must
+    be returned by find_unsettled_trades so startup recovery picks it up
+    instead of orphaning it in the ledger."""
+    db_path = make_db()
+    log_trade(
+        db_path, window_slug="w-placed", side="up", entry_price=0.53,
+        size=10.0, fees=0.0, model_p_up=0.72, market_p_up=0.55, edge=0.18,
+        outcome=None, pnl=None, status="placed",
+        entry_mode="post_only", rest_price=0.53,
+    )
+    log_trade(
+        db_path, window_slug="w-open", side="down", entry_price=0.42,
+        size=5.0, fees=0.0, model_p_up=0.30, market_p_up=0.45, edge=0.12,
+        outcome=None, pnl=None, status="open",
+    )
+    log_trade(
+        db_path, window_slug="w-settled", side="up", entry_price=0.50,
+        size=8.0, fees=0.0, model_p_up=0.70, market_p_up=0.55, edge=0.10,
+        outcome="up", pnl=3.0, status="settled",
+    )
+    rows = find_unsettled_trades(db_path)
+    slugs = {r["window_slug"] for r in rows}
+    assert slugs == {"w-placed", "w-open"}
+    os.unlink(db_path)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -58,6 +58,66 @@ def test_log_and_retrieve_trade():
     os.unlink(db_path)
 
 
+def test_log_trade_persists_entry_mode_and_rest_price():
+    db_path = make_db()
+    log_trade(
+        db_path,
+        window_slug="btc-5m-po-1",
+        side="up",
+        entry_price=0.54,
+        size=10.0,
+        fees=0.115,
+        model_p_up=0.72,
+        market_p_up=0.575,
+        edge=0.145,
+        outcome=None,
+        pnl=None,
+        status="placed",
+        entry_mode="post_only",
+        rest_price=0.54,
+    )
+    trade = find_trade_by_window_slug(db_path, "btc-5m-po-1")
+    assert trade is not None
+    assert trade["entry_mode"] == "post_only"
+    assert trade["rest_price"] == pytest.approx(0.54)
+    # Default behavior still works: FAK row leaves both null.
+    log_trade(
+        db_path,
+        window_slug="btc-5m-fak-1",
+        side="up",
+        entry_price=0.55,
+        size=10.0,
+        fees=0.115,
+        model_p_up=0.72,
+        market_p_up=0.55,
+        edge=0.17,
+        outcome=None,
+        pnl=None,
+        status="open",
+    )
+    fak = find_trade_by_window_slug(db_path, "btc-5m-fak-1")
+    assert fak["entry_mode"] is None
+    assert fak["rest_price"] is None
+    os.unlink(db_path)
+
+
+def test_init_db_is_idempotent_on_new_columns():
+    """Re-running init_db against a DB that already has entry_mode/rest_price
+    columns must not error and must not duplicate the columns."""
+    db_path = make_db()
+    init_db(db_path)  # second call
+    init_db(db_path)  # third call
+    # Explicit close before unlink — Windows holds a file lock on open conns.
+    conn = sqlite3.connect(db_path)
+    try:
+        cols = [row[1] for row in conn.execute("PRAGMA table_info(trades)").fetchall()]
+    finally:
+        conn.close()
+    assert cols.count("entry_mode") == 1
+    assert cols.count("rest_price") == 1
+    os.unlink(db_path)
+
+
 def test_find_trade_by_window_slug_returns_existing_trade_row():
     db_path = make_db()
     log_trade(

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -210,6 +210,36 @@ def test_get_usdc_balance_handles_empty_wallet(mock_clob):
     assert client.get_usdc_balance() == pytest.approx(0.0)
 
 
+def test_get_order_book_returns_sdk_payload(mock_clob):
+    client, inst = _make_client(mock_clob)
+    payload = {
+        "bids": [{"price": "0.56", "size": "100"}],
+        "asks": [{"price": "0.58", "size": "200"}],
+        "timestamp": "1778900000",
+    }
+    inst.get_order_book.return_value = payload
+
+    book = client.get_order_book("TKN-UP")
+
+    assert book == payload
+    inst.get_order_book.assert_called_once_with("TKN-UP")
+
+
+def test_get_order_book_swallows_sdk_error(mock_clob):
+    """Ack-time diagnostic must never break the trade flow on network failures."""
+    client, inst = _make_client(mock_clob)
+    inst.get_order_book.side_effect = RuntimeError("503 service unavailable")
+
+    book = client.get_order_book("TKN-UP")
+
+    assert book == {}
+
+
+def test_get_order_book_dry_run_returns_empty(mock_clob):
+    client, _ = _make_client(mock_clob, dry_run=True)
+    assert client.get_order_book("TKN-UP") == {}
+
+
 def test_fok_limit_price_adds_slippage_ticks():
     from polypocket.config import FOK_SLIPPAGE_TICKS
     assert fok_limit_price(0.40) == pytest.approx(round(0.40 + FOK_SLIPPAGE_TICKS * 0.01, 2))

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -805,7 +805,11 @@ def test_submit_post_only_placed(mock_clob):
 
 def test_submit_post_only_passes_v2_order_args(mock_clob):
     """Call-arg shape: OrderArgs with side=Side.BUY (enum, NOT str), expiration,
-    plus order_type=GTC and post_only=True at the call site."""
+    plus order_type=GTD (when expiration > 0) and post_only=True at the call site.
+
+    GTD-not-GTC is empirical: the server returns 400 'invalid expiration
+    value, it should be equal to 0 as the order is not a GTD order' when a
+    GTC carries a non-zero expiration."""
     from py_clob_client_v2 import OrderType, Side
     client, inst = _make_client(mock_clob)
     inst.create_and_post_order.return_value = {
@@ -826,8 +830,26 @@ def test_submit_post_only_passes_v2_order_args(mock_clob):
     assert args.side != "Side.BUY"
     assert args.expiration == 1_700_000_000
     assert kwargs["options"].tick_size == "0.01"
-    assert kwargs["order_type"] == OrderType.GTC
+    assert kwargs["order_type"] == OrderType.GTD
     assert kwargs["post_only"] is True
+
+
+def test_submit_post_only_uses_gtc_when_expiration_zero(mock_clob):
+    """expiration=0 means 'no server-side expiry' and falls back to GTC.
+    A bot using this path takes full responsibility for driving cancel."""
+    from py_clob_client_v2 import OrderType
+    client, inst = _make_client(mock_clob)
+    inst.create_and_post_order.return_value = {
+        "success": True, "orderID": "po-no-exp", "status": "live",
+    }
+    client.submit_post_only(
+        side="up", size=10.0, price=0.54,
+        token_id="TKN-UP", condition_id="0xCOND",
+        expiration=0,
+    )
+    kwargs = inst.create_and_post_order.call_args.kwargs
+    assert kwargs["order_type"] == OrderType.GTC
+    assert kwargs["order_args"].expiration == 0
 
 
 def test_submit_post_only_would_cross_via_400(mock_clob):

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -469,6 +469,95 @@ def test_get_settlement_info_handles_null_order_body(mock_clob):
     inst.get_trades.assert_not_called()
 
 
+def test_get_settlement_info_counts_maker_fills(mock_clob):
+    """Post-only / GTC orders fill as MAKER, not taker. Our order_id appears
+    inside the fill's `maker_orders[]` array (with its own `matched_amount`
+    and `price`), while `taker_order_id` is the counterparty's. The top-level
+    `size` is the total cross — using it would overcount by orders of
+    magnitude.
+
+    Regression for the cohort run on 2026-05-16 that silently lost ~$25:
+    every post-only fill returned shares_held=0 here, so the bot wrote the
+    trade as 'rejected, post-only-no-fill' while the position settled in
+    the background.
+    """
+    client, inst = _make_client(mock_clob)
+    inst.get_order.return_value = {"associate_trades": ["t1"]}
+    inst.get_trades.return_value = [
+        {
+            "id": "t1",
+            # Total cross was 171.22 shares against 16 makers; our order is
+            # one of those 16 with matched_amount=10. Top-level size and
+            # price are the AGGREGATE — irrelevant to us.
+            "taker_order_id": "0xTAKER",
+            "size": "171.22", "price": "0.5", "fee_rate_bps": "0",
+            "maker_orders": [
+                {"order_id": "0xOTHER1", "matched_amount": "5",  "price": "0.51", "fee_rate_bps": ""},
+                {"order_id": "0xOID",    "matched_amount": "10", "price": "0.49", "fee_rate_bps": ""},
+                {"order_id": "0xOTHER2", "matched_amount": "20", "price": "0.50", "fee_rate_bps": ""},
+            ],
+        },
+    ]
+
+    info = client.get_settlement_info("0xOID")
+
+    # Our slice only: 10 shares @ $0.49 = $4.90; no fee on this match.
+    assert info.shares_held == pytest.approx(10.0)
+    assert info.cost_usdc == pytest.approx(4.90)
+
+
+def test_get_settlement_info_maker_fill_with_fee(mock_clob):
+    """Maker fee_rate_bps is honored when present (some markets charge a
+    nonzero maker fee; empty string and None both mean 0)."""
+    client, inst = _make_client(mock_clob)
+    inst.get_order.return_value = {"associate_trades": ["t1"]}
+    inst.get_trades.return_value = [
+        {
+            "id": "t1", "taker_order_id": "0xTAKER",
+            "size": "20.0", "price": "0.50", "fee_rate_bps": "0",
+            "maker_orders": [
+                {"order_id": "0xOID", "matched_amount": "10", "price": "0.49", "fee_rate_bps": "100"},
+            ],
+        },
+    ]
+
+    info = client.get_settlement_info("0xOID")
+
+    # 10 shares × (1 - 100/10000) = 9.9 shares net of fee; cost is gross 10*$0.49=$4.90.
+    assert info.shares_held == pytest.approx(9.9)
+    assert info.cost_usdc == pytest.approx(4.90)
+
+
+def test_get_settlement_info_aggregates_taker_and_maker_paths(mock_clob):
+    """An order CAN appear as taker on one match and maker on another (rare
+    but possible across the order's lifetime). Both paths must contribute."""
+    client, inst = _make_client(mock_clob)
+    inst.get_order.return_value = {"associate_trades": ["t1", "t2"]}
+
+    def fake_get_trades(params):
+        if params.id == "t1":
+            return [{
+                "id": "t1", "taker_order_id": "0xOID",
+                "size": "5", "price": "0.40", "fee_rate_bps": "0",
+                "maker_orders": [{"order_id": "0xOTHER", "matched_amount": "5", "price": "0.40"}],
+            }]
+        return [{
+            "id": "t2", "taker_order_id": "0xOTHER",
+            "size": "100", "price": "0.99", "fee_rate_bps": "0",
+            "maker_orders": [
+                {"order_id": "0xOID", "matched_amount": "3", "price": "0.48", "fee_rate_bps": ""},
+            ],
+        }]
+
+    inst.get_trades.side_effect = fake_get_trades
+
+    info = client.get_settlement_info("0xOID")
+
+    # Taker portion: 5 @ $0.40 = $2.00. Maker portion: 3 @ $0.48 = $1.44.
+    assert info.shares_held == pytest.approx(8.0)
+    assert info.cost_usdc == pytest.approx(3.44)
+
+
 def test_cancel_order_success(mock_clob):
     from py_clob_client_v2 import OrderPayload
     client, inst = _make_client(mock_clob)

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -784,7 +784,8 @@ def test_polymarket_client_satisfies_live_order_client_protocol():
 
 
 def test_submit_post_only_placed(mock_clob):
-    """Happy path: SDK returns success+orderID, wrapper returns PlaceResult(placed)."""
+    """Happy path: SDK returns success+orderID, wrapper returns PlaceResult(placed)
+    with placed_size = the tick-safe-quantized integer that actually got signed."""
     client, inst = _make_client(mock_clob)
     inst.create_and_post_order.return_value = {
         "success": True, "orderID": "po-abc", "status": "live",
@@ -797,6 +798,8 @@ def test_submit_post_only_placed(mock_clob):
     assert place.status == "placed"
     assert place.order_id == "po-abc"
     assert place.error is None
+    # 10 shares @ $0.54 = $5.40 — tick-safe; size is integerized.
+    assert place.placed_size == pytest.approx(10.0)
     inst.create_and_post_order.assert_called_once()
 
 

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -4,6 +4,7 @@ import pytest
 
 from polypocket.clients.polymarket import (
     PolymarketClient, _tick_safe_size, fok_limit_price, ioc_limit_price,
+    post_only_rest_price,
 )
 
 
@@ -304,6 +305,42 @@ def test_ioc_limit_price_uses_highest_opposite_bid():
     )
     # 1 - 0.72 + 0.02 = 0.30
     assert limit == pytest.approx(0.30)
+
+
+def test_post_only_rest_price_up_uses_down_bid():
+    """Rest BUY UP at (1 - best_down_bid) - offset_ticks."""
+    down_bids = [{"price": 0.45, "size": 100.0}]
+    rest = post_only_rest_price(
+        side="up", up_bids=[], down_bids=down_bids, offset_ticks=2,
+    )
+    # 1 - 0.45 - 0.02 = 0.53
+    assert rest == pytest.approx(0.53)
+
+
+def test_post_only_rest_price_down_uses_up_bid():
+    """Symmetric: BUY DOWN's pair-merge clearing uses the UP-side best bid."""
+    up_bids = [{"price": 0.60, "size": 100.0}]
+    rest = post_only_rest_price(
+        side="down", up_bids=up_bids, down_bids=[], offset_ticks=3,
+    )
+    # 1 - 0.60 - 0.03 = 0.37
+    assert rest == pytest.approx(0.37)
+
+
+def test_post_only_rest_price_no_opp_bid_returns_none():
+    """No counterparty on opposite side → no pair-merge possible at any offset."""
+    assert post_only_rest_price(side="up", up_bids=[], down_bids=[], offset_ticks=2) is None
+    assert post_only_rest_price(side="up", up_bids=[], down_bids=None, offset_ticks=2) is None
+
+
+def test_post_only_rest_price_floors_at_one_cent():
+    """Extreme opp_bid pushing rest below 0.01 must clamp to 0.01."""
+    # 1 - 0.99 - 0.05 = -0.04 → clamp to 0.01.
+    down_bids = [{"price": 0.99, "size": 10.0}]
+    rest = post_only_rest_price(
+        side="up", up_bids=[], down_bids=down_bids, offset_ticks=5,
+    )
+    assert rest == 0.01
 
 
 def test_get_settlement_info_sums_trades(mock_clob):
@@ -740,7 +777,126 @@ def test_polymarket_client_satisfies_live_order_client_protocol():
     PolymarketClient without updating the executor's Protocol or call sites,
     this test catches it at import time."""
     for method in (
-        "submit_fok", "submit_ioc", "cancel_order",
+        "submit_fok", "submit_ioc", "submit_post_only", "cancel_order",
         "get_usdc_balance", "get_settlement_info", "get_order_status",
     ):
         assert hasattr(PolymarketClient, method), f"PolymarketClient missing {method}"
+
+
+def test_submit_post_only_placed(mock_clob):
+    """Happy path: SDK returns success+orderID, wrapper returns PlaceResult(placed)."""
+    client, inst = _make_client(mock_clob)
+    inst.create_and_post_order.return_value = {
+        "success": True, "orderID": "po-abc", "status": "live",
+    }
+    place = client.submit_post_only(
+        side="up", size=10.0, price=0.54,
+        token_id="TKN-UP", condition_id="0xCOND",
+        expiration=int(1_700_000_000),
+    )
+    assert place.status == "placed"
+    assert place.order_id == "po-abc"
+    assert place.error is None
+    inst.create_and_post_order.assert_called_once()
+
+
+def test_submit_post_only_passes_v2_order_args(mock_clob):
+    """Call-arg shape: OrderArgs with side=Side.BUY (enum, NOT str), expiration,
+    plus order_type=GTC and post_only=True at the call site."""
+    from py_clob_client_v2 import OrderType, Side
+    client, inst = _make_client(mock_clob)
+    inst.create_and_post_order.return_value = {
+        "success": True, "orderID": "po-1", "status": "live",
+    }
+    client.submit_post_only(
+        side="up", size=10.0, price=0.54,
+        token_id="TKN-UP", condition_id="0xCOND",
+        expiration=1_700_000_000,
+    )
+    kwargs = inst.create_and_post_order.call_args.kwargs
+    args = kwargs["order_args"]
+    assert args.token_id == "TKN-UP"
+    assert args.price == pytest.approx(0.54)
+    assert args.size == pytest.approx(10.0)
+    # Guards against str(Side.BUY) regression: must be the enum value, not "Side.BUY".
+    assert args.side == Side.BUY
+    assert args.side != "Side.BUY"
+    assert args.expiration == 1_700_000_000
+    assert kwargs["options"].tick_size == "0.01"
+    assert kwargs["order_type"] == OrderType.GTC
+    assert kwargs["post_only"] is True
+
+
+def test_submit_post_only_would_cross_via_400(mock_clob):
+    """v2 server raises PolyApiException(400) when post-only would cross."""
+    from py_clob_client_v2.exceptions import PolyApiException
+    client, inst = _make_client(mock_clob)
+    exc = PolyApiException.__new__(PolyApiException)
+    exc.status_code = 400
+    exc.error_msg = {
+        "error": "post_only order would cross the book",
+        "orderID": "po-xc",
+    }
+    inst.create_and_post_order.side_effect = exc
+
+    place = client.submit_post_only(
+        side="up", size=10.0, price=0.54,
+        token_id="TKN-UP", condition_id="0xCOND", expiration=1_700_000_000,
+    )
+    assert place.status == "rejected"
+    assert place.error == "post-only-would-cross"
+    assert place.order_id == "po-xc"
+
+
+def test_submit_post_only_would_cross_via_success_false(mock_clob):
+    """Defensive: server may also surface cross-rejection as success=False
+    with errorMsg text instead of a 400 — wrapper detects either shape."""
+    client, inst = _make_client(mock_clob)
+    inst.create_and_post_order.return_value = {
+        "success": False, "orderID": "po-xc2",
+        "errorMsg": "post_only_would_cross",
+    }
+    place = client.submit_post_only(
+        side="up", size=10.0, price=0.54,
+        token_id="TKN-UP", condition_id="0xCOND", expiration=1_700_000_000,
+    )
+    assert place.status == "rejected"
+    assert place.error == "post-only-would-cross"
+    assert place.order_id == "po-xc2"
+
+
+def test_submit_post_only_network_error(mock_clob):
+    """Non-400, non-classifiable exception → status=error with 'network:' prefix."""
+    client, inst = _make_client(mock_clob)
+    inst.create_and_post_order.side_effect = RuntimeError("conn reset")
+    place = client.submit_post_only(
+        side="up", size=10.0, price=0.54,
+        token_id="TKN-UP", condition_id="0xCOND", expiration=1_700_000_000,
+    )
+    assert place.status == "error"
+    assert place.error.startswith("network:")
+
+
+def test_submit_post_only_tick_safe_unfixable(mock_clob):
+    """Patched _tick_safe_size returning None → rejected with tick-size-unfixable."""
+    client, inst = _make_client(mock_clob)
+    with patch("polypocket.clients.polymarket._tick_safe_size", return_value=None):
+        place = client.submit_post_only(
+            side="up", size=10.0, price=0.54,
+            token_id="TKN-UP", condition_id="0xCOND", expiration=1_700_000_000,
+        )
+    assert place.status == "rejected"
+    assert place.error == "tick-size-unfixable"
+    inst.create_and_post_order.assert_not_called()
+
+
+def test_submit_post_only_dry_run(mock_clob):
+    """Dry-run returns synthetic placed result without calling the SDK."""
+    client, inst = _make_client(mock_clob, dry_run=True)
+    place = client.submit_post_only(
+        side="up", size=10.0, price=0.54,
+        token_id="TKN-UP", condition_id="0xCOND", expiration=1_700_000_000,
+    )
+    assert place.status == "placed"
+    assert place.order_id == "DRY-RUN"
+    inst.create_and_post_order.assert_not_called()


### PR DESCRIPTION
## Summary

Adds a maker-side execution path as a structural fix for the live-v2 calibration gap diagnosed 2026-05-16 (paper-vs-live DOWN-side gap ~11.7pt; the FAK was racing for top-of-book liquidity that vanished by ack-time). Default `ENTRY_MODE=fak` keeps current behavior bit-identically; flipping to `ENTRY_MODE=post_only` rests a GTC + post_only order at `pmc − 2 ticks` and cancel-reconciles at `t_remaining ≤ 30s`.

Design + implementation docs: `docs/plans/2026-05-15-post-only-entries-design.md` and `…-implementation.md`.

Key constraints honored:
- Gate, sizing, cushion, signal model: untouched.
- Paper path: bit-identical (verified by `test_paper_path_unchanged_with_post_only_config_set`).
- Protocol seam: `LiveOrderClient` gains one method (`submit_post_only`) and one new dataclass (`PlaceResult`).
- Config: four new env-backed constants, all added to `tests/conftest.py::_key`.

## Validation done in this PR

- All 366 tests green (up from 344 baseline).
- Paper-mode bit-identity guard: ENTRY_MODE=post_only in paper still calls `execute_paper_trade`, never enters post-only.
- Post-hoc replay against `paper_trades.db` (1669 eligible decisions): 28.9% fill rate at offset=2 — in the plausible 15-80% band. Median post-decision fill at ~30s. Sample report at `scripts/_post_only_replay.md`.
- Cancel-race integration test exercises the load-bearing failure mode (cancel returns False but `get_settlement_info` reveals a partial fill — CLOB state authoritative; row promotes to `open`).
- Recovery branch: a CLOB `status='live'` order from a previous run gets cancel-reconciled inline by `reconcile_recovered_trade`.

## NOT done in this PR (requires human at keyboard with credentials)

- **Step 9 live probe** (per implementation plan): one min-size single-shot post-only against the production CLOB to verify:
  - Server response shape for `success`/`status=live`.
  - Expiration units (Unix seconds vs ms) — drop the `int(time.time()) + 60` order and verify it dies at ~60s wall-clock.
  - Would-cross rejection shape (place at `pmc + 1` deliberately).
- After the probe lands, document any error-text-shape adjustments needed in `_classify_post_only_cross_error`.
- **Live promotion** to `ENTRY_MODE=post_only` is an ops change (env var on the live process), not a code change.

## Test plan

- [x] Full pytest suite: 366/366 green.
- [x] Replay script runs against `paper_trades.db`, emits sensible report.
- [x] Cancel-race partial-fill integration test (`test_cancel_post_only_order_cancel_race_partial_fill`).
- [x] Paper bit-identity guard with ENTRY_MODE=post_only.
- [ ] **Live probe** (Step 9 of implementation plan) — run before flipping `ENTRY_MODE=post_only` in any live process.
- [ ] **Small live cohort** (Phase 4 of design doc) — 50–100 trades at \$5/trade, measure live calibration vs paper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)