### PR TITLE
docs(model): v3 logistic refit HALTED — design premise invalidated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ reports/
 .cohort_start
 .cohort_stop
 _bmad/
+_bmad-output/*.parquet
 corpus.parquet
 corpus*.parquet
 

--- a/docs/plans/2026-05-17-logistic-p-up-v3-design.md
+++ b/docs/plans/2026-05-17-logistic-p-up-v3-design.md
@@ -1,0 +1,214 @@
+# Logistic p_up v3 — refit on the 5,076-row post-G1 corpus
+
+> **STATUS: HALTED 2026-05-18** — investigated end-to-end; both v0 and v0.1
+> variants fail §Q4. The design's "regime drift on the 0.80+ bins" premise
+> was invalidated by primary evidence: the drift was time-localized to the
+> early post-cutover period and has fully mean-reverted on the slice v3 would
+> evaluate against. v2 stays the active gate. Full evidence in
+> `scripts/_model_v3_training.md`; training infrastructure preserved at
+> `scripts/train_model_v3.py` as a starting point for any future refit.
+
+**Date:** 2026-05-17
+**Companion (deferred):** `2026-05-17-logistic-p-up-v3-implementation.md` — drafted after this design is approved.
+**Depends on:** the post-G1 capture pipeline (`#16` / G1–G5, shipped 2026-04-24) that supplies this plan's corpus; the v2 training pipeline at `docs/plans/2026-04-23-logistic-p-up-model-design.md` (this plan extends rather than replaces it — same model class, calibration layer, dual-logging discipline, and acceptance shape).
+**Sequenced after:** `2026-05-17-post-only-retirement-design.md`. The retirement removes the active bleeding mechanism; this plan fixes the bin-level model drift that retirement explicitly carried forward as known risk (§"What can break" row 3 of that plan).
+**Closes (if promoted to live):** the 0.80–0.85 / 0.85–0.90 calibration drift that surfaced in the post-only-retirement review; opens a clean baseline for the next live FAK cohort plan.
+
+**Correction note (2026-05-17, during impl-plan drafting):** v2 was actually trained 2026-05-12 on **n=4,461 rows**, not on n=404 as my earlier draft of this design claimed by reading the v2 *design* doc (which projected n=404 at design time, before the data shipped). The v2 *training report* at `scripts/_model_v2_training.md` is the authoritative source. v2 also ships **without isotonic calibration** — the iso step pushed held-out log-loss from 0.451 to 0.629 and was dropped. This design has been updated throughout to reflect those facts; the goal of v3 shifts from "fix tail-bin starvation" to "address regime drift on a slightly larger corpus + test the deferred book-depth features." The core recommendation — refit, two corpora variants, gate must beat v2 — is unchanged.
+
+## Problem
+
+The v2 logistic model (`model_p_up_v2`, trained 2026-05-12 on n=4,461 paper post-G1 rows, **no isotonic** per `scripts/_model_v2_training.md:6-8` — the isotonic step pushed held-out log-loss from 0.451 to 0.629 and was dropped) passed its own training held-out gate at the 0.80+ tail (gap +1.3pt at n=273) but has drifted in production. Two structural misses, surfaced by the 2026-05-17 retirement diagnostic and `scripts/_model_health.md`:
+
+| slice | bin | n | mean p_pred | actual wr | gap |
+|---|---|---:|---:|---:|---:|
+| post-cutover paper, all-eligible | 0.80–0.85 | 125 | 0.815 | 71.2% | **−10.2pt** |
+| post-cutover paper, all-eligible | 0.85–0.90 | 131 | 0.878 | 74.0% | **−13.8pt** |
+| live FAK v2 cohort (n=20) | overall DOWN | 35 | 83.1% | 71.4% | **−11.7pt** |
+
+Source: `_bmad-output/v2_failure_diagnostics_modelver.md:26-29`, `scripts/_model_health.md:80-96`. The bin-level drift is on the *all-eligible* paper population — not the post-only filled subset — meaning it's a model-calibration issue separate from the post-only fill mechanism. A FAK-only bot would see this drift on every high-confidence decision.
+
+**This is regime drift, not tail-bin starvation.** v2's training held-out (`scripts/_model_v2_training.md:24-31`) had n=273 in the 0.80–1.00 band with gap +1.3pt — the tail was supported, the calibration was real. The drift opened up *after* v2 became the active gate: production decisions between 2026-05-09 (`model_p_up_v2` first populated) and 2026-05-15 show the 0.85–0.90 bin sliding from −9pt (30-day model_health window) to −13.8pt (post-cutover diagnostic slice). v3's task is to refit with the recent regime included in training, plus test whether the book-depth features v2 deferred for corpus-coverage reasons (1,667 bids-populated rows now, vs. v2's training-time floor of 150) add a feature that anticipates regime shifts.
+
+### Corpus inventory (verified 2026-05-17 against `paper_trades.db`)
+
+Joining `window_snapshots` decision rows to close rows on `window_slug`, post-G1 (≥ 2026-04-24 — one stable gate config, post-`5f76bea`):
+
+| corpus slice | rows | feature set | notes |
+|---|---:|---|---|
+| v0 (4-feature) | **5,076** | displacement, sigma_5min, t_remaining, market_p_up_normalized | v2 trained on 4,461 rows; v3 adds the 615 rows captured 2026-05-12 → 2026-05-15 (the recent regime where v2's drift opened up). Both fired (n=1,667) and skipped (n=4,069) decisions included — BTC-derived outcomes are fill-independent per v2 §"Empirical grounding". |
+| v0.1 (book-depth features) | **1,667** | v0 + bids JSON parses | 11× the v2 design's "revisit v0.1 at 150" floor. Only the gated subset captures bids JSON; this is a deliberate restriction. v2 had ~78 bids-populated live rows at its training time, far short of any reliable v0.1 fit. |
+| v2 column populated (dual-log slice) | 1,499 | n/a | Since 2026-05-09 — used to compare v3-vs-v2 directly without re-running v2 from scratch. |
+
+Date range: 2026-04-24 → 2026-05-15, 21 days, fully covered across all UTC hours (53–100 fired rows/hour). At 60/20/20 chronological split on the v0 corpus: train ~3,045 / calibrate ~1,015 / **held-out ~1,015**. The held-out 0.80+ bin should populate with 150–300 rows depending on v3's distribution at the tail — plenty for tight bin-level claims; the held-out tail-bin support is *not* the bottleneck for v3 (it wasn't for v2 either — v2 had n=273 at 0.80–1.00 in its own held-out and still drifted in production). The bottleneck v3 has to address is **regime change between training and deployment**, which is the same risk v2 acknowledged but couldn't fix.
+
+### What this plan does NOT claim to fix
+
+- **Post-only adverse selection (−25.4pt filled-cohort gap).** Structural to the fill mechanism. No decision-time feature can predict whether the book will move adversely post-decision — confirmed by the regime-split exhaustive search in `_bmad-output/v2_failure_diagnostics_extra.md`. v3 may shift which decisions land in the filled cohort but does not change the conditional-distribution gap.
+- **Live FAK execution-seam (racing/thinning at ack).** Tracked separately via the `book_at_ack` diagnostic (`polypocket/executor.py:412-435`) and the deferred Phase 3 live cohort plan. v3 may *partially* narrow the live −11.7pt DOWN gap, but the execution-seam contribution is unmeasurable until the next live cohort with `book_at_ack` populated.
+
+## Goal
+
+Ship `compute_model_p_up_v3` as a third L2 logistic model — **no isotonic by default** (v2's training revealed isotonic overfit on this corpus and pushed log-loss from 0.451 to 0.629; v3 carries that lesson forward, with isotonic re-tested only as an ablation now that the corpus is larger) — behind `MODEL_VERSION=v3`. Dual-logged in `model_p_up_v3` column alongside v1 and v2. Promoted to gate after passing reliability on a held-out slice and a dual-logged paper A/B against the live v2 model. Live cutover deferred to a follow-up plan after the post-only-retirement plan's FAK Phase-3 lands. Out of scope: model class changes (L2 logistic stays), regime-conditional models, online learning, backfilling outcomes for pre-G1 windows.
+
+## Key design questions
+
+### 1. Feature set — stay at v0 or expand to v0.1?
+
+**Recommendation: ship v3 at v0.1 with the book-depth additions ablated, default-on if they lift held-out log-loss by ≥0.005 nats.**
+
+The v2 design deferred book-depth because the bids-JSON corpus was 0/564 paper, 78/373 live at training time. It's now 1,667 paper rows under post-G1 capture — meaningfully above the 150-row floor v2 specified for revisiting. The candidates:
+
+- **`book_imbalance = (up_top_size − down_top_size) / (up_top_size + down_top_size)`** — top-of-book size on the side-relevant pair. Hypothesis: book imbalance at decision predicts directional bias of the next 5 minutes, additive to the displacement z-score.
+- **`spread = up_ask + down_ask − 1`** — book tightness; v2 design listed this as an ablation candidate. Should now run on the bigger corpus.
+- **`pre_decision_pmc_sigma`** — std of pmc over `window_book_samples` rows in the same window with `sampled_at < decision_ts`. This is the "pre-decision book volatility" feature the post-only retirement review's Axis 2 named as the strongest unexplored axis. Captures a regime distinction the v2 features can't see.
+- **`z_times_market`** — model-market interaction; carry-over from v2's ablation list.
+
+**Ablation discipline:** each new feature gates on a held-out log-loss lift ≥0.005 nats *and* a reliability-gap improvement at the 0.80+ bins. No-lift features stay out — v3 must be defensible as "the smaller fix that works," not "the kitchen-sink rewrite."
+
+### 2. Training corpus — full 5,076 (v0) or restricted-to-bids 1,667 (v0.1)?
+
+**Recommendation: two corpora, two model variants, ship the better one.**
+
+The v0 fit (5,076 rows, 4 features) is the conservative baseline — same feature set as v2 with 12× the data. Almost certainly closes the 0.80+ drift just by having tail support, regardless of feature engineering.
+
+The v0.1 fit (1,667 rows, 4 + up to 4 new features) tests whether book-depth features add value beyond more data. Trained on 33% the row count but with richer feature support.
+
+Both go through identical train/calibrate/eval gates; the held-out log-loss + reliability comparison chooses the shipped variant. If v0.1 ties v0 on the gates, ship v0 (simpler, larger support). If v0.1 beats v0 on the 0.80+ bins specifically, ship v0.1 (the bin we're trying to fix is the gate). This is decided by the report, not pre-committed.
+
+### 3. Train/calibrate/eval split
+
+**Single chronological 60/20/20 on each corpus**, per v2 design's structure. v0: train ~3,045 / calibrate ~1,015 / held-out ~1,015. v0.1: train ~1,000 / calibrate ~333 / held-out ~333. Time-series 5-fold CV inside the training slice for L2 strength + feature-ablation selection. No shuffling, no leakage.
+
+**Held-out date range:** the last ~4 days of paper data (2026-05-11 to 2026-05-15 approximately). This is the most recent regime; if v3 is going to be promoted to gate the next live FAK cohort, the held-out should look like what live will see.
+
+### 4. Acceptance gate — what's tighter than v2's?
+
+v2's gate was ±5pt per bin with size-conditional CI fallback at the tail. v3's gate inherits that structure with three additions:
+
+- **Tail-bin must beat v2 point-estimate.** At 0.80–0.85: v3 gap point estimate must be **better than v2's −10.2pt by ≥5pt** (i.e., v3 ≥ −5pt). At 0.85–0.90: better than v2's −13.8pt by ≥8pt (i.e., v3 ≥ −6pt). This is the bin we're refitting to fix — half-measures fail.
+- **DOWN-side overall gap ∈ [−5pt, +5pt].** Tighter than the retirement plan's ±7pt blocker because v3's whole point is calibration tightness. v2's current DOWN gap is −4.6pt; v3 should hold or improve.
+- **Log-loss improvement on held-out.** v3 held-out log-loss must beat v2's evaluated on the same held-out rows by ≥0.005 nats. (v2's current Brier on the 30-day paper window is 0.1269 per `scripts/_model_health.md`; held-out log-loss is the comparable continuous metric.) Smaller deltas are inside CI noise at n≈1,000.
+
+**Pre-committed veto:** if v3's simulated PnL on the held-out is *worse* than v2's by a 95% bootstrap CI entirely below zero (same as v2's veto rule), ship is blocked regardless of calibration metrics.
+
+### 5. DOWN-side asymmetry — feature or training-side rebalance?
+
+**Recommendation: side-aware training, not a side-conditional feature.**
+
+The v2 model produces `p_up` independent of which side the bot will trade; the side is decided downstream. Adding `preview_side` as a feature would leak gate-decision logic into the model. The cleaner fix is to confirm v3 is trained on **both up-leaning and down-leaning rows** with their actual outcomes — which the v0 corpus naturally is (1,727 down-side decisions, 3,349 up-side, ~62%/58% win rates respectively). Class balance is reasonable; no rebalancing weights needed.
+
+If after training v3 still shows ≥5pt DOWN-vs-UP gap divergence, that's a *model* issue not fixable by features alone — at that point we revisit either (a) a side-conditional intercept term (lightest fix) or (b) two separate logistics (heavier). Don't pre-commit to either; let the held-out report drive it.
+
+### 6. What about regime-conditional models (sigma quintile, displacement quintile)?
+
+Out of scope, same as v2 design. With 5,076 rows split 5 ways you'd have ~1,000/regime which is enough in principle, but the cross-validation surface explodes and the v2 design's "kitchen-sink risk" argument still holds. A single L2 logistic with appropriate features is the v3 swing; regime-conditional is v4 territory if v3 still misses.
+
+### 7. Dual-logging columns and back-compat
+
+v3 ships a new `model_p_up_v3 REAL` column on `window_snapshots`. The three coexisting columns become:
+
+- `model_p_up` — the version that actually fired the trade (back-compat, mutates over time as `MODEL_VERSION` flips).
+- `model_p_up_v1_calibrated` — v1, always.
+- `model_p_up_v2` — v2, always.
+- `model_p_up_v3` — v3, always (NEW).
+
+Reader scripts (`scripts/_model_health.py`, `_bmad-output/v2_failure_diagnostics_*.py`) read the version-specific columns directly, never `model_p_up`. Same discipline as v2.
+
+### 8. Promotion sequence — paper A/B then live?
+
+Same as v2 design's Phase A/B: dual-log v3 unconditionally; gate stays on v2 until the A/B report shows v3 passes the same reliability gate on ≥200 fresh decisions with the 0.80+ bin n≥30 (higher floor than v2's n=20 because we have more data). Then flip `MODEL_VERSION=v3` in paper.
+
+**Live promotion is NOT part of this plan.** Live promotion happens only after:
+1. v3 passes paper A/B.
+2. The post-only-retirement plan's Phase 3 (deferred live FAK cohort) lands as a separate plan and runs successfully.
+3. A combined v3+FAK live cohort plan is written.
+
+This three-step deferral is deliberate. Conflating "new model" with "new execution mode" on live capital is the kind of confounded experiment the v2 paper-vs-live transfer risk warned against.
+
+## What can break
+
+| Failure mode | Severity | Mitigation |
+|---|---|---|
+| **v3 closes the 0.80–0.85 / 0.85–0.90 bins but opens a new miss elsewhere.** Often happens with isotonic calibration on small bins — moving probability mass around. | Medium | Acceptance gate (§Q4) is bin-level for all n≥30 bins, not just the tail. If a middle bin regresses, gate fails. |
+| **v0.1 features overfit on n=1,667 with up to 8 features.** Pre-decision book-vol could be especially leaky if the join is wrong. | Medium | Time-series 5-fold CV inside training slice catches in-fold overfitting; held-out is fresh data and exposes out-of-distribution. Each new feature gates on log-loss lift ≥0.005 nats — small lift = stays out. |
+| **Held-out gate passes but v3 drifts in production the same way v2 did.** v2 had a clean held-out gate (+1.3pt at 0.80–1.00, n=273) and still drifted to −9 to −14pt within weeks of deployment. v3 cannot rule this out from a single training pass on the same kind of corpus. | Medium | The paper A/B (Phase 3) is the primary check — v3 must hold its calibration on a *fresh* slice generated under its own gate decisions, not just on the chronologically-newest training split. Add a post-promotion monitoring step to the runbook: `scripts/model_health.py` produces v3 reliability tables weekly, and any 0.80+ bin gap exceeding −5pt for two consecutive weeks triggers a refit conversation. |
+| **Tail-bin n≥30 still not met under v3's distribution.** If v3 produces fewer ≥0.85 rows than v2 (e.g., shrinks confidence toward the mode), the tail bin we're trying to gate stays sparse. | Low | v2's training held-out had n=273 at 0.80–1.00; v3 trains on a slightly larger corpus with the same target distribution. Tail-bin starvation is unlikely. Escape hatch carried over from v2's design as defense-in-depth: if A/B tail bin hasn't reached n=30 in 7 days, flip paper bot to `MODEL_VERSION=v3` for 2 additional days so v3's gate populates v3's tail. |
+| **Held-out is contaminated by the same regime we're fitting.** 21 days isn't a lot of regime variation; a 4-day held-out at the tail of that window is even less. v3 could be over-fit to the May 2026 microstructure regime. | Medium | Documented as deployment risk in the runbook. Live promotion (separate plan) gates on a post-cutover monitoring window with explicit rollback. Not solvable inside this plan; the corpus is what it is. |
+| **DOWN-side gap persists at ≥5pt even after refit.** Suggests the asymmetry lives in the signal-data interaction (BTC microstructure responds differently to up vs. down displacement) rather than in model fit. | Medium | Q5's two-fallback path: side-conditional intercept or two-separate-logistics. Both are gated on held-out evidence, not pre-committed. If neither helps, the next plan is feature engineering — log-spread asymmetry, time-of-day-conditional DOWN behavior. |
+| **Refit closes paper FAK calibration but live FAK still shows the −11.7pt gap.** Most of the live gap was execution-seam, not model. | Low (expected) | Out of scope. The book_at_ack diagnostic + Phase 3 live cohort plan owns this. v3 closes only the model contribution. |
+| **The v2 column stops being maintained after v3 ships.** A later reader script reads `model_p_up_v2` and gets stale or null data. | Low | Dual-logging discipline (§Q7): all three version-specific columns are populated unconditionally on every decision regardless of `MODEL_VERSION`. v2 column stays accurate until explicit retirement (separate cleanup, not this plan). |
+| **Training pipeline regression vs v2's** (notebook drift, sklearn version drift, scaler differences). | Low | v3 uses the same training script structure as v2 (`scripts/train_model_v2.py` → `scripts/train_model_v3.py`). Single artifact: `polypocket/model_v3_coefs.json` with same schema as `model_v2_coefs.json`. Reproducibility test: re-running training from the corpus + seed produces identical coefficients. |
+| **Model exporter has train/serve skew** — the bot's runtime `compute_model_p_up_v3` reads features differently than the training script does. | Medium | Same CI test discipline as v2: a unit test pins the feature dict that `compute_model_p_up_v3` receives and asserts it matches the training feature list. `market_p_up_normalized` re-derived from `up_ask` / `down_ask` at both training and serving, never read from `d.market_p_up` directly. |
+
+## Files touched (preview)
+
+| File | Change |
+|---|---|
+| `polypocket/model_v3_coefs.json` (NEW) | Fitted coefficients, intercept, isotonic breakpoints, training metadata block. ~5KB committed. |
+| `polypocket/observer.py` | Add `compute_model_p_up_v3(features: dict) -> float`. Existing `compute_model_p_up`, `compute_model_p_up_v2`, and `compute_model_p_up_active` dispatcher stay. Dispatcher gains `v3` route. |
+| `polypocket/config.py` | `MODEL_VERSION` default stays at `v2` until paper A/B passes; no change in this PR. After A/B promotion: change default to `v3` in a follow-up commit. |
+| `polypocket/ledger.py` | Idempotent ALTER on `window_snapshots`: add `model_p_up_v3 REAL`. Extend the decision-snapshot exporter to populate it. |
+| `polypocket/signal.py` | No behavioral change in this PR. The dispatcher in `observer.py` is the only edit point. |
+| `scripts/train_model_v3.py` (NEW) | Training script. No `scripts/train_model_v2.py` exists in tree (v2 was trained from a one-shot notebook); v3's script is a new, committed reproducible artifact built around `scripts/export_training_corpus.py` (the existing parquet exporter, used as-is). v0 + v0.1 corpus paths, ablation harness, single-artifact output. |
+| `scripts/_model_v3_training.md` (NEW, committed) | Training report: corpus summary, feature lists per variant, CV log-loss per fold, ablation results, held-out reliability tables, simulated EV comparison vs v2, ship recommendation. |
+| `scripts/compare_model_versions.py` | Extend to read v3 column. Replace its hardcoded v1-vs-v2 logic with `--versions v2,v3` (or similar). |
+| `scripts/_model_v3_paper_ab.md` (NEW, generated after dual-log A/B window) | Paper A/B report: v3 vs v2 on fresh decisions, per-bin reliability, promotion verdict. |
+| `tests/test_observer.py` | New tests: `compute_model_p_up_v3` exists, accepts the documented feature dict, produces float in [0,1], and matches the coefficients JSON. Train/serve skew guard. |
+| `docs/runbooks/model-versions.md` (NEW or extend if exists) | Document v3, the corpora variants, the rollback procedure (`MODEL_VERSION=v2` flips back instantly), and the known limitations (no fix for post-only adverse selection, no fix for live execution-seam). |
+
+Explicitly NOT touched: any `signal.py` gate logic, `executor.py`, `risk.py`, `bot.py`, `feat/post-only-v2-design` branch contents, `live_trades.db` (read-only access for any live-vs-paper comparison reports).
+
+## Validation plan
+
+### Phase 1 (mandatory before ship): training-time held-out gate
+
+1. **Corpus extraction.** Run `scripts/train_model_v3.py --corpus v0` and `--corpus v0.1` against `paper_trades.db`. Verify row counts match the expected 5,076 / 1,667. Date range printed in the report.
+2. **Train both variants** with time-series 5-fold CV. Report per-fold log-loss, chosen L2 strength, chosen feature subset (for v0.1 — which book-depth features made the cut).
+3. **Held-out reliability table** for each variant. Apply the §Q4 acceptance gate: ±5pt per n≥30 bin, tail-bin point estimate beats v2 by required margin (≥5pt at 0.80–0.85, ≥8pt at 0.85–0.90), DOWN gap ∈ [−5pt, +5pt], log-loss beats v2 by ≥0.005 nats.
+4. **Pick a winner** based on Q4 criteria. If both pass, prefer v0 (simpler, larger support). If only v0.1 passes the 0.80+ tail-bin requirement, ship v0.1. If neither passes, halt; surface to user.
+5. **Veto check.** Simulated PnL bootstrap CI on held-out — v3 must not be entirely below v2.
+
+**Acceptance:** the chosen variant has a green held-out gate; `polypocket/model_v3_coefs.json` is committed with the report.
+
+### Phase 2 (mandatory before paper-A/B promotion): integration
+
+1. Wire `compute_model_p_up_v3` into the `observer.py` dispatcher.
+2. Add `model_p_up_v3` column to `window_snapshots` (idempotent ALTER).
+3. Extend the decision-snapshot exporter to populate the column on every decision, regardless of `MODEL_VERSION`.
+4. `pytest` green, including the new train/serve skew guard test.
+5. Smoke run in paper for 1 hour. Verify the v3 column is populating; verify `MODEL_VERSION=v2` still drives the gate; verify v3 numbers in the column are sensible (not all 0.5, not all 1.0, range and distribution match training).
+
+**Acceptance:** dual-logging is live in paper; no regression in v2 gate behavior.
+
+### Phase 3 (mandatory before live promotion plan unblocks): paper A/B
+
+1. Wait for ≥200 fresh decisions with both `model_p_up_v2` and `model_p_up_v3` populated. At ~250–300 decisions/day in paper, ~1 wall-clock day.
+2. Verify the 0.80+ v3 bin has n≥30. If not, escape-hatch: flip paper to `MODEL_VERSION=v3` for 2 more days to populate v3's own tail.
+3. Run `scripts/compare_model_versions.py --versions v2,v3 --output scripts/_model_v3_paper_ab.md`.
+4. Apply the same acceptance gate as Phase 1 on the A/B slice. Additionally: v3's gaps must not be ≥5pt worse than its Phase-1 held-out gaps (regime-drift guard).
+
+**Acceptance:** A/B gate passes; v3 is promotable to paper gate. Flip `MODEL_VERSION=v3` default in `polypocket/config.py` in a follow-up commit (this is a small, reversible config edit, not a code change).
+
+### Phase 4 (DEFERRED — separate plan): live cutover
+
+Not part of this plan. The live-cutover plan depends on (a) v3 paper A/B passing, (b) post-only-retirement plan's Phase 3 (live FAK cohort) being written and approved, and (c) explicit user GO. Probably a combined "v3 + FAK live probe + small cohort" plan.
+
+## Go / no-go criterion for the human
+
+**GO if all hold:**
+
+1. You agree the 0.80+ bin drift on the all-eligible paper cohort is a real model issue, separate from the post-only adverse-selection seam and from the live FAK execution seam.
+2. You're comfortable with the "no model class change" constraint — staying on L2 logistic + isotonic, just refit with more data and tested feature additions.
+3. The acceptance gate (§Q4) is the right tightness — specifically that v3 must *beat* v2 on the bins we're trying to fix, not just stay within ±5pt of perfect.
+4. The deferred live cutover (Phase 4 separate plan) is the right operating discipline; you don't want to bundle "new model" with "live FAK promotion" on the same PR.
+
+**NO-GO triggers — revise this design:**
+
+- You want regime-conditional models (revise §Q6 to argue for separate volatility-regime fits). Heavier scope, but defensible at 5,076 rows.
+- You want to try GBDT or similar (revise: v2 design's "out of scope" rule was on n=404; at n=5,076 it's plausible to revisit. Cost: more hyperparameters, more CV variance, harder to reason about feature importance).
+- You want to refit while the post-only retirement plan is still in flight rather than waiting for it to merge (revise: probably fine since the corpora are independent, but it loses the "clean baseline" framing the sequencing was built on).
+- You want to bundle live promotion into this plan rather than deferring to a separate plan (revise Phase 4: argue for combined v3-and-FAK-live scope; the v2 design's paper→live transfer caveat is the counter-argument).
+- You want a different acceptance gate at the 0.80+ tail (revise §Q4: the margin numbers — ≥5pt at 0.80–0.85, ≥8pt at 0.85–0.90 — are proposals derived from v2's current gap; tighter or looser is a user-tolerance call).
+
+**Decision required:** GO / NO-GO. If GO, the companion implementation plan covers: (a) `scripts/train_model_v3.py` build + corpus extraction + training run, (b) `model_v3_coefs.json` commit, (c) `observer.py` dispatcher + ledger ALTER + tests, (d) paper A/B report + verdict, (e) `MODEL_VERSION` default flip (follow-up commit after A/B), (f) memory updates. If NO-GO, your reason determines what changes — feature set, model class, scope, or gate tightness.

--- a/docs/plans/2026-05-17-logistic-p-up-v3-implementation.md
+++ b/docs/plans/2026-05-17-logistic-p-up-v3-implementation.md
@@ -1,0 +1,322 @@
+# Logistic p_up v3 — implementation plan
+
+> **STATUS: HALTED 2026-05-18 at Step 4.** Steps 1–4 executed; both variants
+> failed §Q4. Steps 5–12 not started. v2 remains the active gate; no
+> production code changed. See `scripts/_model_v3_training.md` for the full
+> negative-result report.
+
+**Companion:** `2026-05-17-logistic-p-up-v3-design.md`. Read that first; this doc is the linear step-by-step build.
+
+**Branch:** a new branch off `main` after the post-only-retirement PR has merged. Suggested name: `feat/logistic-p-up-v3`. Sequencing rule from the design: do not start until retirement is merged so the v3 work has a clean v2 baseline + the wallet watchdog in place.
+
+**Test discipline:** the production-code surface is small — one new function in `observer.py`, an idempotent ledger ALTER, and one new test. The training script + report live in `scripts/` and don't run in CI. Run `pytest` after Step 7. Each step's "acceptance" is the concrete check that must pass before the next step starts.
+
+**Total scope estimate:** ~1.5–2 days focused, plus 1–2 wall-clock days waiting on Phase 3 paper A/B after PR merges. Promotion (the `MODEL_VERSION` default flip) is a small follow-up commit.
+
+**Dependencies installed:**
+- `pip install -e ".[ml]"` — provides sklearn ≥1.3, pandas ≥2.0, pyarrow ≥14. The `ml` extra already exists in `pyproject.toml`; no new dependencies are added by this plan.
+
+---
+
+## Step 1 — sanity-check the existing corpus exporter, dump v0 + v0.1 parquets
+
+**Files:** read-only check on `scripts/export_training_corpus.py`; produce two parquet files under a temp/working directory (not committed — these are derived, easily regenerated).
+
+`scripts/export_training_corpus.py` already exists from v2 (verified 2026-05-17). It joins `decision` → `close` rows on `window_slug`, filters to `outcome IN ('up','down')` + non-null core features + `t_remaining > 0`, normalizes `market_p_up = up_ask / (up_ask + down_ask)`, and writes parquet. It also persists `up_bids_json` / `down_bids_json` per-row, which is what v0.1 needs.
+
+1. Read `scripts/export_training_corpus.py` end-to-end. Confirm:
+   - `DEFAULT_SINCE = "2026-04-24 00:00:00"` (the G1 cutoff).
+   - `CORE_FIELDS` covers the v0 features (displacement, sigma_5min, t_remaining, up_ask, down_ask).
+   - Bids JSON is persisted unconditionally (used by v0.1).
+   - `outcome_int = 1 if up else 0` is the training label.
+2. Run the exporter:
+   - `python scripts/export_training_corpus.py --out _bmad-output/v3_corpus.parquet`
+3. Inspect with a one-liner:
+   - `python -c "import pandas as pd; df = pd.read_parquet('_bmad-output/v3_corpus.parquet'); print(df.shape, df['outcome_int'].mean(), df['decision_timestamp'].min(), df['decision_timestamp'].max(), df['up_bids_json'].notna().sum())"`
+   - Expected: shape `(5076, 14)`, base rate ≈ 0.51, date span 2026-04-24 → 2026-05-15, bids-populated count ≈ 1667.
+
+**Acceptance for Step 1:**
+- `_bmad-output/v3_corpus.parquet` exists; row count matches the design's §"Corpus inventory" (5,076 v0 rows; 1,667 with bids).
+- If the count is off by more than ±5%, halt and diagnose before training. A capture-pipeline regression between 2026-05-12 (when v2's corpus was extracted) and now would invalidate the corpus comparability.
+- Note `_bmad-output/v3_corpus.parquet` should be **gitignored** if it isn't already (large derived file). Confirm: `git check-ignore -v _bmad-output/v3_corpus.parquet`. If not ignored, append `_bmad-output/*.parquet` to `.gitignore`.
+
+---
+
+## Step 2 — build `scripts/train_model_v3.py`
+
+**Files:** `scripts/train_model_v3.py` (new), `polypocket/model_v2_coefs.json` (read-only — used as the comparison baseline).
+
+The script is the **first committed reproducible training pipeline** for this project — v2 was trained from a one-shot notebook and the only artifact left behind is `_model_v2_training.md` plus the coefficients JSON. v3's training script needs to be re-runnable on the same corpus and produce identical coefficients (modulo random-seed determinism).
+
+Structure (mirrors `_model_v2_training.md`'s sections so the v3 report drops into the same shape):
+
+1. **Inputs:**
+   - `--corpus` (default `_bmad-output/v3_corpus.parquet`).
+   - `--variant` (choices: `v0`, `v0.1`, `both`; default `both`).
+   - `--seed` (default `42`, matches v2).
+   - `--out-coefs` (default `polypocket/model_v3_coefs.candidate.json` — *.candidate* until Step 4 chooses the winner and renames).
+   - `--out-report` (default `scripts/_model_v3_training.md`).
+   - `--baseline-coefs` (default `polypocket/model_v2_coefs.json` — for the v2-vs-v3 held-out comparison).
+2. **Data loading and split:**
+   - Load parquet, sort by `decision_timestamp`, drop rows with `t_remaining <= 0`.
+   - Chronological 60/20/20: train = first 60%, calibrate = next 20% (unused for shipped no-iso variant; reserved for iso ablation), held-out = last 20%.
+   - For v0.1: additional filter — `up_bids_json IS NOT NULL AND down_bids_json IS NOT NULL`, then apply the same 60/20/20 split.
+   - Print row counts and date spans per split.
+3. **Feature engineering:**
+   - **v0 features:**
+     - `z = displacement / (sigma_5min * sqrt(t_remaining / 300))` — guard against `t_remaining <= 0` (already filtered).
+     - `t_remaining` (seconds, normalized internally by `StandardScaler`).
+     - `sigma_5min`.
+     - `market_p_up_normalized` (already in parquet as a column).
+   - **v0.1 additions** (each gated on ablation lift):
+     - `book_imbalance` = parse `up_bids_json[0]['size']` and `down_bids_json[0]['size']`, compute `(up_size - down_size) / (up_size + down_size)`. Default to 0 on parse failure (shouldn't happen post-filter).
+     - `spread = up_ask + down_ask - 1`.
+     - `pre_decision_pmc_sigma` — requires a second SQL query against `paper_trades.db` joining `window_book_samples` rows with `sampled_at < decision_ts`. Compute pmc from each sample's bids, take std. **Implementation note:** this is the only feature requiring a DB round-trip; cache the result back into the parquet at first run to avoid re-querying. If the per-window sample count is < 3, fall back to `sigma_5min` (proxy).
+     - `z_times_market = z * market_p_up_normalized`.
+4. **Standardization:** `StandardScaler` fit on the training slice (full-train scope, not per-fold — v2 design's documented choice; ~ε difference at n>1k per v2's own ablation `_model_v2_training.md:69-72`).
+5. **CV inside training slice:** `TimeSeriesSplit(n_splits=5)`. Grid search L2 strength `C ∈ {0.1, 1.0, 10.0, 100.0}`. Pin `C=10.0` to match v2 if multiple are tied within 1e-4 log-loss (v2's documented heuristic, `_model_v2_training.md:9`). Report per-fold log-loss in the output.
+6. **Held-out evaluation:** for each variant, compute on the held-out slice:
+   - Log-loss, Brier.
+   - Reliability table at the v3 design's bin widths: 0.50–0.60, 0.60–0.70, 0.70–0.80, 0.80–0.85, 0.85–0.90, 0.90–1.00. (Finer bins at the tail than v2's 0.80–1.00 because the v3 gate distinguishes 0.80–0.85 from 0.85–0.90 — that's the point of the refit.)
+   - DOWN-side vs UP-side overall gap. (Side computed as `1 - p_pred` for outcome=down rows when matching the gate's downstream side decision; preserve v2's convention.)
+   - Bootstrap 95% CI on each bin's actual win rate (1000 resamples).
+7. **Apply the §Q4 acceptance gate** per the design doc:
+   - All n≥30 bins: gap ∈ [−5pt, +5pt].
+   - 0.80–0.85 bin: gap ≥ −5pt (i.e., better than v2's −10.2pt by ≥5pt).
+   - 0.85–0.90 bin: gap ≥ −6pt (i.e., better than v2's −13.8pt by ≥8pt — adjusted because v2's number is on production, not v2's held-out).
+   - DOWN-side overall gap ∈ [−5pt, +5pt].
+   - Held-out log-loss < `v2_holdout_logloss − 0.005`.
+   - PnL veto: bootstrap 95% CI on (v3_PnL − v2_PnL) on held-out is not entirely below zero. **Implementation note:** to compute this without a live gate, simulate fires using the gate config persisted in `gate_config_json` on each row — there's already a path to this in `polypocket/signal.py::evaluate_gate_config_*` (use it directly to avoid forking the gate logic).
+8. **Ablations** (report-only, not gate-blocking):
+   - v0 vs v0.1 head-to-head log-loss.
+   - Each v0.1 feature individually (drop one, retrain, report delta).
+   - With-isotonic vs no-isotonic — verify v2's "iso hurt" finding still holds on the larger corpus. If iso *helps* by ≥0.01 nats and doesn't fail the bin gate, ship v3 with isotonic and override the no-iso default. Note this in the report.
+9. **Winner selection** (mechanical, no human-in-the-loop at this point):
+   - If both v0 and v0.1 pass §Q4, ship **v0** (simpler, larger support).
+   - If only one passes, ship the one that passes.
+   - If neither passes, write the report anyway, exit with code 1, and surface the failure to the user via Step 5.
+10. **Output:** the winning variant's coefficients to `--out-coefs` and the full report to `--out-report`. Report includes a `## Gate verdict` block at the top with `ship_ok: True|False` and the chosen variant name.
+
+**Acceptance for Step 2:**
+- Script exists and is end-to-end executable.
+- A dry run on the parquet from Step 1 produces both files. Report is human-readable markdown; coefs JSON has the same top-level keys as `polypocket/model_v2_coefs.json` (the existing v2 file is the reference schema).
+- Re-running the script with the same `--seed` produces a bitwise-identical coefs JSON. (Determinism check: run twice, `diff` the two outputs.)
+
+---
+
+## Step 3 — train and inspect the v0 variant
+
+1. Run: `python scripts/train_model_v3.py --variant v0 --out-coefs polypocket/model_v3_coefs.v0.candidate.json --out-report scripts/_model_v3_training.v0.md`
+2. Read the report. Verify the §"Gate verdict" block exists and reports clearly.
+3. Cross-check the v2-on-v3-holdout numbers against `_model_v2_training.md` for sanity — v2's training held-out was 2026-05-09 → 2026-05-12, but v3's held-out is 2026-05-12 → 2026-05-15. Different rows, but the same regime; v2's evaluation on v3's held-out tests whether v2 generalizes to the recent slice. Expected: v2 evaluated on v3's held-out shows a worse log-loss than v2 on its own held-out. If not, the design's "regime drift" diagnosis is suspect and we should surface to user before continuing.
+
+**Acceptance for Step 3:**
+- v0 report written; gate verdict is one of `ship_ok: True` or `ship_ok: False` with a one-line summary of which criterion failed.
+- v2-on-v3-holdout numbers sanity-check against the regime-drift hypothesis.
+- No silent training failures (NaN coefs, all-zero gradients, etc.).
+
+---
+
+## Step 4 — train v0.1 and inspect ablations
+
+1. Run: `python scripts/train_model_v3.py --variant v0.1 --out-coefs polypocket/model_v3_coefs.v01.candidate.json --out-report scripts/_model_v3_training.v01.md`
+2. Read the report. Specifically check:
+   - The per-feature ablation table — which book-depth features actually moved log-loss.
+   - The v0.1 §"Gate verdict" — does v0.1 pass §Q4?
+3. Compare v0 vs v0.1 directly. Note in the report which one is shipped.
+4. **If both pass:** keep v0 (simpler). Delete the `v01.candidate.json`. Rename `model_v3_coefs.v0.candidate.json` → `polypocket/model_v3_coefs.json`. The shipped report is `scripts/_model_v3_training.md` (union of v0 + v0.1 sections).
+5. **If only v0.1 passes:** keep v0.1. Rename `model_v3_coefs.v01.candidate.json` → `polypocket/model_v3_coefs.json`. Document the choice in the report.
+6. **If both pass and v0.1 beats v0 on the 0.80–0.85 / 0.85–0.90 bins specifically by ≥2pt:** ship v0.1 (the bins we're refitting to fix are the gate).
+7. **If neither passes:** halt this plan. The retirement still stands; the next plan is either a model class change (out of scope of v3) or a refit-with-regime-conditional-models (out of scope of v3). Surface to user.
+
+**Acceptance for Step 4:**
+- Both reports exist; the merged Step-5 report (after winner selection) is the committed artifact.
+- Exactly one `polypocket/model_v3_coefs.json` (no `.candidate.` suffix, no v0/v0.1 marker — the file is the shipping artifact, the variant is recorded in the JSON's `metadata.variant` field and in the training report).
+- The other variant's candidate file is deleted from the working tree.
+
+---
+
+## Step 5 — commit the training artifacts
+
+**Files:** `scripts/train_model_v3.py`, `scripts/_model_v3_training.md`, `polypocket/model_v3_coefs.json`.
+
+1. `git add scripts/train_model_v3.py scripts/_model_v3_training.md polypocket/model_v3_coefs.json`.
+2. Commit message: `feat(model): train v3 logistic on n=5,076 post-G1 corpus`. Body references the design doc and names the chosen variant (v0 or v0.1) + the headline numbers (overall held-out log-loss, 0.80–0.85 bin gap, 0.85–0.90 bin gap, DOWN gap).
+3. `git diff HEAD~1 --stat` to confirm exactly three new files.
+
+**Acceptance for Step 5:**
+- One commit on `feat/logistic-p-up-v3` with the three files.
+- No production code changed yet — this commit is purely training artifacts.
+
+---
+
+## Step 6 — ledger ALTER for `model_p_up_v3` column
+
+**Files:** `polypocket/ledger.py` (one block), `tests/test_ledger.py` (one new test).
+
+1. Locate the existing schema migration block for `model_p_up_v2` in `polypocket/ledger.py`. Mirror its pattern for `model_p_up_v3 REAL`. Use the same `ALTER TABLE … ADD COLUMN … IF NOT EXISTS`-equivalent idempotent SQL (sqlite doesn't have `IF NOT EXISTS` for ADD COLUMN; the existing code uses a try/except wrapper — copy it).
+2. Add a test in `tests/test_ledger.py` mirroring the existing v2 column test: open a fresh DB, run init, assert `PRAGMA table_info(window_snapshots)` includes `model_p_up_v3`.
+3. Run the migration manually against both `paper_trades.db` and (if present) `live_trades.db`:
+   - `python -c "from polypocket.ledger import init_db; init_db('paper_trades.db'); init_db('live_trades.db')"`
+   - Verify with: `python -c "import sqlite3; c = sqlite3.connect('paper_trades.db'); print([r[1] for r in c.execute('PRAGMA table_info(window_snapshots)').fetchall() if 'model_p_up' in r[1]])"` — expected output includes `model_p_up_v3`.
+
+**Acceptance for Step 6:**
+- `model_p_up_v3` column present on `window_snapshots` in both DBs.
+- New test passes.
+- Re-running `init_db` is idempotent (doesn't fail because the column already exists).
+
+---
+
+## Step 7 — implement `compute_model_p_up_v3` + dispatcher update
+
+**Files:** `polypocket/observer.py`, `tests/test_observer.py`.
+
+1. In `polypocket/observer.py`, add `compute_model_p_up_v3(features: dict) -> float`:
+   - Load coefficients lazily from `polypocket/model_v3_coefs.json` on first call; cache. Mirror the v2 implementation pattern verbatim.
+   - Read the same feature dict shape v2 reads (the v3 design specifies no train/serve skew — features must be derived from values already on the decision row).
+   - For v0: 4 features. For v0.1: 4 + N book-depth features per the chosen variant. The coefs JSON's `metadata.features` list is the source of truth for feature names + order.
+   - Return a float in [0, 1]; clamp on numerical edge cases.
+2. Extend `compute_model_p_up_active`'s dispatcher: add `elif model_version == "v3": return compute_model_p_up_v3(features)`.
+3. Update the decision-snapshot exporter (the `_persist_decision_snapshot` or equivalent function in `polypocket/signal.py` or `polypocket/ledger.py` — locate by grepping for the line that writes `model_p_up_v2` into the row). Add a parallel `model_p_up_v3` write that always populates the column regardless of `MODEL_VERSION`. **Critical:** the v0.1 variant requires bids JSON at decision time — if `up_bids_json IS NULL OR down_bids_json IS NULL`, write `NULL` to `model_p_up_v3` and skip the call rather than passing zeros to the feature builder. This is a meaningful divergence from v2's unconditional dual-log.
+4. New unit test in `tests/test_observer.py`:
+   - `test_compute_model_p_up_v3_returns_float_in_range` — synthetic feature dict, assert 0 ≤ output ≤ 1.
+   - `test_compute_model_p_up_v3_feature_list_matches_coefs` — load the coefs JSON, assert `metadata.features` == the feature dict keys produced by the production exporter for a sample decision. This is the **train/serve skew guard** from the v3 design's §"What can break" row 9.
+   - `test_compute_model_p_up_v3_v01_returns_null_without_bids` — only if the shipped variant is v0.1. Pass a feature dict with `up_bids = None` and assert the wrapper returns None (or raises a sentinel exception caught by the exporter).
+
+**Acceptance for Step 7:**
+- The three new tests pass.
+- `compute_model_p_up_active` correctly routes `MODEL_VERSION=v3` to the new function.
+- Decision-snapshot exporter populates `model_p_up_v3` on every decision (or NULL when v0.1 features are unavailable).
+
+---
+
+## Step 8 — pytest + smoke run
+
+1. Full pytest. Expected: baseline + 3 new tests + 1 ledger test = ~4 net new tests, all green.
+2. Smoke run in paper for **1 hour minimum**:
+   - Confirm `MODEL_VERSION` env var stays `v2` (the gate is unchanged — v3 is dual-logged only).
+   - Tail the bot log for one or more decisions; verify the log line `Decision: ... model_p_up=...` shows the v2 value (not v3).
+   - Query `paper_trades.db` after the smoke: `SELECT timestamp, model_p_up, model_p_up_v2, model_p_up_v3 FROM window_snapshots WHERE snapshot_type='decision' ORDER BY id DESC LIMIT 10;` — expected: `model_p_up_v3` is non-NULL on all rows (v0 variant) or non-NULL on most rows with bids available (v0.1 variant).
+   - Verify v3 values are in a sensible range (not all 0.5, not all 0.99) — compare distribution to v2 column on the same rows. v3's mean should be within ±0.05 of v2's mean across the smoke rows.
+
+**Acceptance for Step 8:**
+- `pytest` green.
+- Smoke run produces ≥10 decision rows with both `model_p_up_v2` and `model_p_up_v3` populated (for v0 variant) or ≥10 rows total with ≥80% having v3 populated (for v0.1 variant).
+- Visual check: v3 values are sensible. No silent failure mode.
+
+---
+
+## Step 9 — commit integration + open PR
+
+1. `git add polypocket/ledger.py polypocket/observer.py polypocket/signal.py tests/test_ledger.py tests/test_observer.py`. The exporter changes from Step 7 likely touch `signal.py` (or wherever `_persist_decision_snapshot` lives — locate before adding).
+2. Commit message: `feat(model): integrate v3 dispatcher + dual-log + tests`. Body lists the test count delta and links to the design doc.
+3. `git log feat/logistic-p-up-v3 --oneline` — expect 2 commits: training artifact (Step 5) + integration (Step 9).
+4. `gh pr create` with title `feat: train v3 logistic, dual-log behind MODEL_VERSION`. Body:
+   - References the design doc.
+   - Names the shipped variant (v0 or v0.1).
+   - Lists the headline calibration improvements vs v2 (0.80–0.85 bin gap delta, DOWN gap delta, held-out log-loss delta).
+   - Explicitly states: **this PR does not flip the active model — `MODEL_VERSION=v2` remains the gate until Phase 3 paper A/B passes (post-merge).**
+
+**Acceptance for Step 9:**
+- PR exists, all CI checks pass.
+- PR description makes the "v3 dual-logged, v2 still gates" status explicit so a reviewer doesn't worry the bot's behavior changed under them.
+
+---
+
+## Step 10 (post-merge, deferred ~1–2 days) — Phase 3 paper A/B
+
+This is **not in the PR** — it runs after PR merge against the production paper data the deployed v3 dual-logger collects.
+
+1. Build `scripts/compare_model_versions.py` (it does NOT exist on `main`; the v2 design proposed it and never shipped). The script:
+   - Inputs: `--db paper_trades.db`, `--versions v2,v3`, `--out scripts/_model_v3_paper_ab.md`.
+   - Queries `window_snapshots` for decisions where both `model_p_up_v2` and `model_p_up_v3` are non-null and the joined close row has an outcome.
+   - Per-bin reliability for both versions side-by-side.
+   - Simulated gate-fire PnL for both versions at current live config (reuse the simulation path from Step 2's training script).
+   - Bootstrap 95% CI on the per-bin gap delta (v3 − v2) and on the simulated PnL delta.
+   - **Promotion verdict per the design's §"Phase 3" gate:**
+     - Same acceptance as Phase 1 (§Q4) on the fresh A/B slice.
+     - v3 gaps must not be ≥5pt worse than v3's Phase-1 held-out gaps (regime-drift guard).
+2. Wait for ≥200 fresh decisions with both columns populated. At paper's ~250–300 decisions/day this is ~1 wall-clock day.
+3. If the 0.80+ v3 bin has n<30 at the 200-row mark, invoke the v3 design's escape hatch:
+   - Flip paper to `MODEL_VERSION=v3` for 2 wall-clock days.
+   - During this window, v3 drives the gate AND populates the v3 tail. v2 stays dual-logged.
+   - At the end, re-run the comparison.
+4. Run `python scripts/compare_model_versions.py --versions v2,v3 --out scripts/_model_v3_paper_ab.md`.
+5. Read the verdict.
+
+**Acceptance for Step 10:**
+- A/B report exists at `scripts/_model_v3_paper_ab.md`.
+- The §"Promotion verdict" block reports a clear GO or NO-GO.
+- If GO → proceed to Step 11.
+- If NO-GO → halt. Document the failure mode. v2 remains the gate; v3 stays dual-logged. The next plan is either v3.1 (feature additions, drift handling) or a model class change.
+
+---
+
+## Step 11 (post-A/B, GO only) — flip `MODEL_VERSION=v3` default
+
+**Files:** `polypocket/config.py`. **Not** `.env` — the default lives in code, and `.env` is gitignored.
+
+1. Edit `polypocket/config.py`: change `MODEL_VERSION = os.getenv("MODEL_VERSION", "v2")` to `MODEL_VERSION = os.getenv("MODEL_VERSION", "v3")`.
+2. Run pytest. The change should be invisible to most tests; any test that pinned `MODEL_VERSION=v2` for cross-version comparison needs to explicitly set the env var via `monkeypatch.setenv("MODEL_VERSION", "v2")`. Locate and fix.
+3. Restart the bot. Verify the first decision after restart logs `model_p_up` matching the `model_p_up_v3` column (i.e., v3 is the active gate).
+4. Update the runbook (`docs/runbooks/model-versions.md` — created in Step 5 of the v3 design's §"Files touched", or appended if it exists from another plan):
+   - Document the v3 promotion + paper A/B numbers.
+   - Document the rollback procedure: `MODEL_VERSION=v2` in `.env` flips back instantly without code changes.
+5. Commit: `chore(model): promote v3 to default MODEL_VERSION (Phase 3 paper A/B passed)`. Reference the A/B report.
+
+**Acceptance for Step 11:**
+- `MODEL_VERSION` default is `v3` in `polypocket/config.py`.
+- pytest green.
+- Bot restart confirmed; v3 is the active gate in paper.
+- Runbook updated with the rollback procedure.
+
+---
+
+## Step 12 — memory updates
+
+Update one memory and add one. Use `Write` against the memory files; pointer entries go in `MEMORY.md`.
+
+1. **Update `[[project_live_v2_execution_gap]]`:** add a line at the end pointing to v3's promotion as the model-side mitigation. Keep the "do not refit" history visible — the constraint was correctly held until the new evidence emerged and v3 is the response.
+2. **New memory `project_logistic_v3_promoted.md`:** type=project. Frontmatter `name: project-logistic-v3-promoted`, description names the version and date. Body: (a) what changed (v3 trained on n=5,076 paper post-G1; variant v0 or v0.1; ships no-isotonic per v2's iso-overfit finding); (b) why (regime drift on v2's 0.80+ bins, surfaced by the post-only retirement review); (c) what it does NOT fix (post-only adverse selection, live FAK execution seam — both are out of scope and tracked separately); (d) rollback procedure. `**Why:**` and `**How to apply:**` lines per the memory rules.
+3. **Update `MEMORY.md`** with the new pointer line:
+   ```markdown
+   - [Logistic v3 promoted YYYY-MM-DD](project_logistic_v3_promoted.md) — refit on n=5,076 post-G1 corpus closes the 0.80+ regime drift; v2 stays as the rollback target
+   ```
+
+**Acceptance for Step 12:**
+- Two memory files updated, one added.
+- `MEMORY.md` has the new pointer.
+
+---
+
+## What is NOT in this PR (or this plan)
+
+- **Live cutover to v3.** Requires (a) v3 paper A/B passing (Step 10), (b) the post-only-retirement plan's Phase 3 (live FAK cohort) being written and run, (c) a combined "v3 + FAK live cohort" plan that the user explicitly approves.
+- **Retiring v1 and v2 columns.** Both stay populated indefinitely as rollback targets. v1 retirement was originally proposed in the v2 design as a post-2-week cleanup; that cleanup is still deferred (and `MODEL_VERSION=v1` is the deepest rollback option if both v3 and v2 are somehow compromised).
+- **Backfilling `model_p_up_v3` on pre-2026-05-17 rows.** v3's feature derivations don't depend on anything not already on the decision row, so it would be technically possible — but the value is unclear and the storage is non-trivial. Skip; v3 column populates forward only.
+- **GBDT, regime-conditional models, online learning.** Same out-of-scope as the v3 design.
+- **Touching the post-only retirement work**, `feat/post-only-v2-design`, or the wallet watchdog.
+
+---
+
+## Estimated effort
+
+| Step | What | Time |
+|---:|---|---:|
+| 1 | Corpus sanity-check | ~20 min |
+| 2 | Build training script | ~3–4 hr |
+| 3 | Train + inspect v0 | ~30 min (incl. CV runtime) |
+| 4 | Train + inspect v0.1 + ablations | ~1 hr |
+| 5 | Commit training artifacts | ~10 min |
+| 6 | Ledger ALTER + test | ~30 min |
+| 7 | Observer dispatcher + tests | ~1 hr |
+| 8 | pytest + smoke run | ~1.5 hr (1 hr is the smoke wait) |
+| 9 | Commit + PR | ~15 min |
+| 10 | Phase 3 paper A/B (post-merge) | ~1–2 wall-clock days; ~2 hr active work |
+| 11 | MODEL_VERSION flip (post-A/B GO) | ~30 min |
+| 12 | Memory updates | ~20 min |
+
+**Total active focused work:** ~8–10 hours.
+**Calendar:** ~3 days end-to-end (1 day for Steps 1–9, 1–2 days waiting for A/B, ~1 hour for Steps 11–12).
+
+The gating risks are Step 4 (does the v0 or v0.1 variant actually pass §Q4?) and Step 10 (does v3 hold up on fresh paper data?). If Step 4 fails, the plan halts and surfaces to user before any production code is touched. If Step 10 fails, v2 remains the gate and v3 stays as dual-logged data without a default flip — no rollback needed because nothing changed in production gating.

--- a/scripts/_model_v3_training.md
+++ b/scripts/_model_v3_training.md
@@ -1,0 +1,161 @@
+# v3 logistic p_up training report
+
+_seed=42; sklearn LogisticRegression L2; TimeSeriesSplit n_splits=5_
+
+## Status: HALTED 2026-05-18 — design premise invalidated
+
+The v3 design (`docs/plans/2026-05-17-logistic-p-up-v3-design.md`) targeted a
+"regime drift on the 0.80+ bins" diagnosed at -10.2pt (0.80-0.85) and -13.8pt
+(0.85-0.90) in `_bmad-output/v2_failure_diagnostics_modelver.md` (2026-05-17,
+n=125/131 on the post-cutover `trade_fired=1 + bids` slice).
+
+Time-localizing the same diagnostic filter:
+
+| slice | n | 0.80-0.85 v2 gap |
+|---|---:|---:|
+| FULL post-cutover (2026-04-24 -> 2026-05-18) | 689 | **-10.8pt** (reproduces diagnostic) |
+| EARLY (2026-04-24 -> 2026-05-11) | 261 | **-20.9pt** |
+| LATE (2026-05-11 -> 2026-05-18 = v3 holdout window) | 428 | **-0.3pt** |
+
+The drift was concentrated in the early post-cutover period when v2 had limited
+tail-bin support; it has self-healed on the slice v3 would be evaluated against.
+v2 is currently calibrated; v3 has nothing to fix at the 0.80+ tail.
+
+**Both variants below FAIL §Q4 acceptance.** No coefs JSON committed. v2 remains
+the active gate (`MODEL_VERSION=v2`).
+
+Next-action options (per design's NO-GO list):
+1. Monitor v2 health; refit only when fresh drift appears (recommended).
+2. Pivot to the bins that ARE drifting per current `_model_health.md`:
+   0.60-0.65 (+8.8pt) and 0.65-0.70 (+10.4pt) are under-confident — different
+   problem from v3's target. Would need a new design.
+3. Model class change (GBDT etc.) — tracked as a separate GitHub issue.
+
+Detailed results below; the training infrastructure (`scripts/train_model_v3.py`)
+is preserved on this branch as a starting point for any future refit.
+
+## Gate verdict: ship_ok = False (no variant passed §Q4)
+
+## Variant: `v0` (FAIL)
+
+- Features: ['z', 't_remaining', 'sigma_5min', 'market_p_up_normalized']
+- N train=3165 cal=1055 heldout=1055
+- train dates: 2026-04-24 14:35:00 ->2026-05-07 18:55:30
+- heldout dates: 2026-05-11 13:41:33 ->2026-05-18 16:05:51
+- base rate (up): train=0.513  held=0.511
+- chosen L2 C = 100.0; CV means: {0.1: 0.406420629561249, 1.0: 0.38119302728824167, 10.0: 0.378605253067855, 100.0: 0.3783823814561}
+
+### Held-out metrics
+- v3 log-loss = 0.3356; v3 Brier = 0.1055
+- v2-on-v3-holdout log-loss = 0.3362
+- v2-on-v2-holdout log-loss (reference, _model_v2_training.md) = 0.4514
+- delta (v3 - v2) on v3 holdout = -0.0006 nats (required ≤ -0.005 for gate)
+
+### v3 reliability (held-out)
+| bin | n | mean_pred | actual | gap_pt | 95% CI |
+|---|---:|---:|---:|---:|---:|
+| 0.50-0.60 | 32 | 0.541 | 0.406 | -13.5 | [0.250, 0.594] |
+| 0.60-0.70 | 35 | 0.652 | 0.743 | +9.0 | [0.600, 0.886] |
+| 0.70-0.80 | 110 | 0.770 | 0.836 | +6.6 | [0.764, 0.909] |
+| 0.80-0.85 | 68 | 0.823 | 0.765 | -5.9 | [0.662, 0.868] |
+| 0.85-0.90 | 42 | 0.877 | 0.905 | +2.8 | [0.810, 0.976] |
+| 0.90-1.00 | 250 | 0.985 | 0.988 | +0.3 | [0.972, 1.000] |
+
+### v2 reliability on the same held-out rows
+| bin | n | mean_pred | actual | gap_pt | 95% CI |
+|---|---:|---:|---:|---:|---:|
+| 0.50-0.60 | 37 | 0.548 | 0.405 | -14.3 | [0.270, 0.568] |
+| 0.60-0.70 | 30 | 0.654 | 0.800 | +14.6 | [0.633, 0.933] |
+| 0.70-0.80 | 121 | 0.768 | 0.818 | +5.0 | [0.744, 0.884] |
+| 0.80-0.85 | 59 | 0.822 | 0.780 | -4.2 | [0.678, 0.881] |
+| 0.85-0.90 | 42 | 0.877 | 0.881 | +0.4 | [0.786, 0.976] |
+| 0.90-1.00 | 249 | 0.984 | 0.992 | +0.8 | [0.980, 1.000] |
+
+### Side decomposition (gate-aligned)
+- UP-bias v3: n=452 mean_pred=0.908 actual=0.920 gap=+1.2pt | v2: n=454 gap=+1.6pt
+- DOWN-bias v3: n=478 mean_pred=0.808 actual=0.872 gap=+6.5pt | v2: n=474 gap=+7.2pt
+
+### Simulated EV under live gate (held-out)
+- v3 total PnL: $+3737.14
+- v2 total PnL: $+3682.50
+- delta (v3 - v2) 95% CI: [$-32.63, $+168.55]
+- EV veto: False
+
+### Isotonic ablation
+- no-iso log-loss: 0.3356
+- with-iso log-loss: 0.3377
+- delta (iso - no-iso) = +0.0020 nats (ship iso only if ≤ -0.01 AND iso bin gate passes)
+
+### Gate failures
+- bin 0.50-0.60 gap -13.5pt outside +/-5.0pt (n=32)
+- bin 0.60-0.70 gap +9.0pt outside +/-5.0pt (n=35)
+- bin 0.70-0.80 gap +6.6pt outside +/-5.0pt (n=110)
+- bin 0.80-0.85 gap -5.9pt outside +/-5.0pt (n=68)
+- bin 0.80-0.85 gap -5.9pt < required -5.0pt
+- DOWN overall gap +6.5pt outside +/-5.0pt
+- held-out log-loss 0.3356 not better than v2 (0.3362) by >=0.005 nats
+
+## Variant: `v0.1` (FAIL)
+
+- Features: ['z', 't_remaining', 'sigma_5min', 'market_p_up_normalized', 'book_imbalance', 'spread', 'pre_decision_pmc_sigma', 'z_times_market']
+- N train=1046 cal=349 heldout=349
+- train dates: 2026-04-24 14:36:13 ->2026-05-09 01:39:20
+- heldout dates: 2026-05-12 06:46:25 ->2026-05-18 15:28:13
+- base rate (up): train=0.528  held=0.404
+- chosen L2 C = 0.1; CV means: {0.1: 0.5238433750694294, 1.0: 0.5385733086454599, 10.0: 0.5493880985731998, 100.0: 0.5508726273340889}
+
+### Held-out metrics
+- v3 log-loss = 0.4776; v3 Brier = 0.1527
+- v2-on-v3-holdout log-loss = 0.4631
+- v2-on-v2-holdout log-loss (reference, _model_v2_training.md) = 0.4514
+- delta (v3 - v2) on v3 holdout = +0.0145 nats (required ≤ -0.005 for gate)
+
+### v3 reliability (held-out)
+| bin | n | mean_pred | actual | gap_pt | 95% CI |
+|---|---:|---:|---:|---:|---:|
+| 0.50-0.60 | 3 | 0.509 | 0.333 | -17.6 | [0.000, 1.000] |
+| 0.60-0.70 | 21 | 0.664 | 0.905 | +24.1 | [0.762, 1.000] |
+| 0.70-0.80 | 52 | 0.753 | 0.808 | +5.5 | [0.692, 0.904] |
+| 0.80-0.85 | 22 | 0.821 | 0.909 | +8.8 | [0.773, 1.000] |
+| 0.85-0.90 | 12 | 0.866 | 0.917 | +5.1 | [0.750, 1.000] |
+| 0.90-1.00 | 3 | 0.921 | 1.000 | +7.9 | [1.000, 1.000] |
+
+### v2 reliability on the same held-out rows
+| bin | n | mean_pred | actual | gap_pt | 95% CI |
+|---|---:|---:|---:|---:|---:|
+| 0.50-0.60 | 0 | — | — | — | — |
+| 0.60-0.70 | 0 | — | — | — | — |
+| 0.70-0.80 | 69 | 0.775 | 0.870 | +9.4 | [0.783, 0.942] |
+| 0.80-0.85 | 30 | 0.821 | 0.833 | +1.2 | [0.700, 0.967] |
+| 0.85-0.90 | 9 | 0.868 | 0.889 | +2.1 | [0.667, 1.000] |
+| 0.90-1.00 | 2 | 0.933 | 1.000 | +6.7 | [1.000, 1.000] |
+
+### Side decomposition (gate-aligned)
+- UP-bias v3: n=65 mean_pred=0.814 actual=0.877 gap=+6.3pt | v2: n=110 gap=+6.5pt
+- DOWN-bias v3: n=203 mean_pred=0.735 actual=0.808 gap=+7.3pt | v2: n=236 gap=+5.4pt
+
+### Simulated EV under live gate (held-out)
+- v3 total PnL: $+1190.52
+- v2 total PnL: $+1615.82
+- delta (v3 - v2) 95% CI: [$-588.26, $-242.81]
+- EV veto: True
+
+### Isotonic ablation
+- no-iso log-loss: 0.4776
+- with-iso log-loss: 0.4759
+- delta (iso - no-iso) = -0.0017 nats (ship iso only if ≤ -0.01 AND iso bin gate passes)
+
+### Per-feature ablation (drop-one, retrain at chosen C)
+| dropped | held-out log-loss | Δ vs full |
+|---|---:|---:|
+| book_imbalance | 0.4783 | +0.0007 |
+| spread | 0.4777 | +0.0001 |
+| pre_decision_pmc_sigma | 0.4759 | -0.0017 |
+| z_times_market | 0.4799 | +0.0023 |
+
+### Gate failures
+- bin 0.70-0.80 gap +5.5pt outside +/-5.0pt (n=52)
+- DOWN overall gap +7.3pt outside +/-5.0pt
+- held-out log-loss 0.4776 not better than v2 (0.4631) by >=0.005 nats
+- PnL veto: 95% CI on (v3 - v2) total PnL = [-588.26, -242.81] entirely below zero
+

--- a/scripts/train_model_v3.py
+++ b/scripts/train_model_v3.py
@@ -1,0 +1,772 @@
+"""Train logistic p_up v3 on the n=5,275 paper post-G1 corpus.
+
+Companion design: docs/plans/2026-05-17-logistic-p-up-v3-design.md
+Companion impl:   docs/plans/2026-05-17-logistic-p-up-v3-implementation.md
+
+Outputs the chosen variant's coefficients + a markdown report. Run with:
+
+    python scripts/train_model_v3.py --variant both \
+        --out-coefs polypocket/model_v3_coefs.candidate.json \
+        --out-report scripts/_model_v3_training.md
+
+Or per-variant:
+
+    python scripts/train_model_v3.py --variant v0     ...
+    python scripts/train_model_v3.py --variant v0.1   ...
+
+Reproducibility: seed=42, time-series 5-fold CV inside the chronological 60/20/20
+training slice. Standardization is fit once on the full training slice (v2's
+documented choice; per-fold scaling delta was ε at n>1k per v2's ablation).
+Re-running with the same --seed produces a bitwise-identical coefs JSON.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from contextlib import closing
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.isotonic import IsotonicRegression
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import brier_score_loss, log_loss
+from sklearn.model_selection import TimeSeriesSplit
+from sklearn.preprocessing import StandardScaler
+
+
+# --- Constants matching the polypocket runtime gate (replicated to avoid
+#     importing the runtime, which would couple training to env vars). ---
+SIGNAL_CUSHION_TICKS = 8  # polypocket/config.py:21
+MAX_ENTRY_PRICE = 0.70    # config.py:30
+MIN_MODEL_CONFIDENCE = 0.60       # config.py:41 (DOWN-side floor on 1-p_up)
+MIN_MODEL_CONFIDENCE_UP = 0.75    # config.py:42
+MIN_EDGE_THRESHOLD = 0.10         # config.py:10
+MIN_EDGE_THRESHOLD_DOWN = 0.10    # config.py:26
+MAX_EDGE_THRESHOLD_UP = 0.25      # config.py:36
+FEE_RATE = 0.072                  # config.py:54
+PAPER_POSITION_USDC = 10.0        # mid-range of MIN_POSITION_USDC..MAX_POSITION_USDC
+
+# §Q4 acceptance gate (from the v3 design):
+GATE_BIN_TOL_PT = 5.0              # |gap| ≤ 5pt per n≥30 bin
+GATE_TAIL_8085_MIN_PT = -5.0       # 0.80-0.85 must be ≥ -5pt (beat v2's -10.2)
+GATE_TAIL_8590_MIN_PT = -6.0       # 0.85-0.90 must be ≥ -6pt (beat v2's -13.8 by ≥8pt)
+GATE_DOWN_TOL_PT = 5.0             # DOWN overall ∈ [-5pt, +5pt]
+GATE_LOGLOSS_MARGIN_NATS = 0.005   # held-out log-loss < v2_holdout - 0.005
+
+# Reliability bin edges (finer at the tail than v2's bins, per design §Q4).
+BIN_EDGES = [0.50, 0.60, 0.70, 0.80, 0.85, 0.90, 1.001]
+BIN_LABELS = ["0.50-0.60", "0.60-0.70", "0.70-0.80", "0.80-0.85", "0.85-0.90", "0.90-1.00"]
+
+V0_FEATURES = ["z", "t_remaining", "sigma_5min", "market_p_up_normalized"]
+V01_EXTRA_FEATURES = ["book_imbalance", "spread", "pre_decision_pmc_sigma", "z_times_market"]
+
+V2_HOLDOUT_LOGLOSS = 0.4514  # from scripts/_model_v2_training.md:38
+
+
+def effective_ask(price: float) -> float:
+    """Break-even model probability to buy at `price` (fee inflation)."""
+    return price / (1.0 - FEE_RATE * price * (1.0 - price))
+
+
+def parse_bids(bids_json: str | None) -> list[dict]:
+    if not bids_json:
+        return []
+    try:
+        return json.loads(bids_json)
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+
+def parse_asks(asks_json: str | None) -> list[dict]:
+    return parse_bids(asks_json)
+
+
+def best_price(orders: list[dict]) -> float | None:
+    if not orders:
+        return None
+    try:
+        return max(float(o["price"]) for o in orders)
+    except (KeyError, ValueError, TypeError):
+        return None
+
+
+def add_v0_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Build the four v0 features (matches v2's training shape)."""
+    df = df.copy()
+    df["z"] = df["displacement"] / (df["sigma_5min"] * np.sqrt(df["t_remaining"] / 300.0))
+    # market_p_up_normalized already in parquet
+    return df
+
+
+def _pmc_from_sample(up_asks_json: str | None, down_asks_json: str | None) -> float | None:
+    """Replicate the runtime's market_p_up_normalized from a book sample."""
+    up_asks = parse_asks(up_asks_json)
+    down_asks = parse_asks(down_asks_json)
+    if not up_asks or not down_asks:
+        return None
+    up_ask = min(float(a["price"]) for a in up_asks)
+    down_ask = min(float(a["price"]) for a in down_asks)
+    denom = up_ask + down_ask
+    if denom <= 0:
+        return None
+    return up_ask / denom
+
+
+def compute_pre_decision_pmc_sigma(
+    db_path: str,
+    df: pd.DataFrame,
+    *,
+    min_samples: int = 3,
+) -> pd.Series:
+    """For each (window_slug, decision_ts), std of pmc over pre-decision samples.
+
+    Falls back to sigma_5min when fewer than `min_samples` book samples are
+    available pre-decision (per impl plan §Step 2.3).
+    """
+    out = np.full(len(df), np.nan, dtype=float)
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        for i, row in df.iterrows():
+            slug = row["window_slug"]
+            ts_str = row["decision_timestamp"]
+            try:
+                ts_epoch = datetime.fromisoformat(ts_str).timestamp()
+            except ValueError:
+                ts_epoch = datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S").timestamp()
+            samples = conn.execute(
+                "SELECT up_asks_json, down_asks_json FROM window_book_samples "
+                "WHERE window_slug = ? AND sampled_at < ?",
+                (slug, ts_epoch),
+            ).fetchall()
+            pmcs = []
+            for s in samples:
+                p = _pmc_from_sample(s["up_asks_json"], s["down_asks_json"])
+                if p is not None:
+                    pmcs.append(p)
+            if len(pmcs) >= min_samples:
+                out[i] = float(np.std(pmcs))
+            else:
+                out[i] = float(row["sigma_5min"])  # fallback proxy
+    return pd.Series(out, index=df.index, name="pre_decision_pmc_sigma")
+
+
+def add_v01_features(df: pd.DataFrame, *, db_path: str) -> pd.DataFrame:
+    """Build v0.1 features on top of v0. Mutates a copy."""
+    df = add_v0_features(df).copy()
+    # book_imbalance from top-of-book bid sizes
+    def _imb(row):
+        up_bids = parse_bids(row["up_bids_json"])
+        down_bids = parse_bids(row["down_bids_json"])
+        try:
+            u = float(up_bids[0]["size"]) if up_bids else 0.0
+            d = float(down_bids[0]["size"]) if down_bids else 0.0
+        except (KeyError, ValueError, TypeError):
+            return 0.0
+        s = u + d
+        return 0.0 if s <= 0 else (u - d) / s
+    df["book_imbalance"] = df.apply(_imb, axis=1)
+    df["spread"] = df["up_ask"] + df["down_ask"] - 1.0
+    df["pre_decision_pmc_sigma"] = compute_pre_decision_pmc_sigma(db_path, df)
+    df["z_times_market"] = df["z"] * df["market_p_up_normalized"]
+    return df
+
+
+def chrono_split(df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Chronological 60/20/20 split on decision_timestamp."""
+    df = df.sort_values("decision_timestamp").reset_index(drop=True)
+    n = len(df)
+    a = int(n * 0.6)
+    b = int(n * 0.8)
+    return df.iloc[:a].copy(), df.iloc[a:b].copy(), df.iloc[b:].copy()
+
+
+def fit_logistic(
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    *,
+    timestamps: np.ndarray,
+    c_grid: list[float] = [0.1, 1.0, 10.0, 100.0],
+    seed: int = 42,
+    n_splits: int = 5,
+) -> tuple[LogisticRegression, float, dict[float, float]]:
+    """Time-series CV grid search over L2 strength; pin C=10 on tie (v2 rule).
+
+    Returns (fitted_model, chosen_C, per_C_logloss_means).
+    """
+    tscv = TimeSeriesSplit(n_splits=n_splits)
+    cv_means: dict[float, float] = {}
+    for C in c_grid:
+        fold_losses = []
+        for tr_idx, va_idx in tscv.split(X_train):
+            m = LogisticRegression(
+                C=C, penalty="l2", solver="lbfgs", max_iter=2000, random_state=seed
+            )
+            m.fit(X_train[tr_idx], y_train[tr_idx])
+            p = m.predict_proba(X_train[va_idx])[:, 1]
+            fold_losses.append(log_loss(y_train[va_idx], p, labels=[0, 1]))
+        cv_means[C] = float(np.mean(fold_losses))
+    # Pick best; tie-break toward C=10 if within 1e-4
+    best_C = min(cv_means, key=cv_means.get)
+    if 10.0 in cv_means and abs(cv_means[10.0] - cv_means[best_C]) < 1e-4:
+        best_C = 10.0
+    model = LogisticRegression(
+        C=best_C, penalty="l2", solver="lbfgs", max_iter=2000, random_state=seed
+    )
+    model.fit(X_train, y_train)
+    return model, best_C, cv_means
+
+
+def reliability_table(
+    p_pred: np.ndarray, y: np.ndarray, n_bootstrap: int = 1000, seed: int = 42
+) -> list[dict]:
+    """Per-bin reliability with bootstrap CI on actual win rate."""
+    rng = np.random.default_rng(seed)
+    rows = []
+    for lo, hi, label in zip(BIN_EDGES[:-1], BIN_EDGES[1:], BIN_LABELS):
+        mask = (p_pred >= lo) & (p_pred < hi)
+        n = int(mask.sum())
+        if n == 0:
+            rows.append({"bin": label, "n": 0, "pred": None, "actual": None, "gap_pt": None, "ci": [None, None]})
+            continue
+        pred = float(p_pred[mask].mean())
+        actual = float(y[mask].mean())
+        y_bin = y[mask]
+        boot = rng.choice(y_bin, size=(n_bootstrap, n), replace=True).mean(axis=1)
+        ci = (float(np.quantile(boot, 0.025)), float(np.quantile(boot, 0.975)))
+        rows.append({
+            "bin": label, "n": n, "pred": pred, "actual": actual,
+            "gap_pt": (actual - pred) * 100, "ci": list(ci),
+        })
+    return rows
+
+
+def side_overall_gap(
+    p_pred: np.ndarray, y: np.ndarray, ask_up: np.ndarray, ask_down: np.ndarray
+) -> dict:
+    """Decompose mean-gap by which side the bot would have favored.
+
+    Side rule mirrors signal.py: UP-bias when p_up >= MIN_MODEL_CONFIDENCE_UP,
+    DOWN-bias when p_up <= 1 - MIN_MODEL_CONFIDENCE. Rows in neither band are
+    'no_side' and excluded from the side decomposition.
+    """
+    up_mask = p_pred >= MIN_MODEL_CONFIDENCE_UP
+    down_mask = p_pred <= (1.0 - MIN_MODEL_CONFIDENCE)
+    out = {}
+    for label, mask in [("up", up_mask), ("down", down_mask)]:
+        n = int(mask.sum())
+        if n == 0:
+            out[label] = {"n": 0, "mean_pred": None, "mean_actual": None, "gap_pt": None}
+            continue
+        if label == "up":
+            mean_pred = float(p_pred[mask].mean())
+            mean_actual = float(y[mask].mean())
+        else:
+            mean_pred = float((1.0 - p_pred[mask]).mean())
+            # For DOWN-side, "winning" means outcome=0 (down). y is up=1, so flip.
+            mean_actual = float((1.0 - y[mask]).mean())
+        out[label] = {
+            "n": n, "mean_pred": mean_pred, "mean_actual": mean_actual,
+            "gap_pt": (mean_actual - mean_pred) * 100,
+        }
+    return out
+
+
+def simulate_pnl(
+    p_pred: np.ndarray,
+    y: np.ndarray,
+    up_ask: np.ndarray,
+    down_ask: np.ndarray,
+    up_bids_json: list[str | None],
+    down_bids_json: list[str | None],
+    *,
+    notional: float = PAPER_POSITION_USDC,
+) -> tuple[float, np.ndarray]:
+    """Replicate signal.py's gate + book.py's pair-merge entry, sum PnL per fire.
+
+    Returns (total_pnl, per_row_pnl_array). Non-firing rows contribute 0.
+    """
+    pnl = np.zeros(len(p_pred), dtype=float)
+    for i in range(len(p_pred)):
+        ua = float(up_ask[i])
+        da = float(down_ask[i])
+        if not (0 < ua <= 1 and 0 < da <= 1):
+            continue
+        ub = parse_bids(up_bids_json[i])
+        db = parse_bids(down_bids_json[i])
+        best_down_bid = best_price(db)
+        best_up_bid = best_price(ub)
+        up_entry = (
+            min(0.99, (1.0 - best_down_bid) + SIGNAL_CUSHION_TICKS * 0.01)
+            if best_down_bid is not None else ua
+        )
+        down_entry = (
+            min(0.99, (1.0 - best_up_bid) + SIGNAL_CUSHION_TICKS * 0.01)
+            if best_up_bid is not None else da
+        )
+        p = float(p_pred[i])
+        up_edge = p - effective_ask(up_entry)
+        down_edge = (1.0 - p) - effective_ask(down_entry)
+        up_aligned = p >= MIN_MODEL_CONFIDENCE_UP
+        down_aligned = p <= (1.0 - MIN_MODEL_CONFIDENCE)
+        up_price_ok = up_entry < MAX_ENTRY_PRICE
+        down_price_ok = down_entry < MAX_ENTRY_PRICE
+        side, entry = None, None
+        if (up_aligned and up_price_ok
+                and up_edge >= MIN_EDGE_THRESHOLD
+                and up_edge < MAX_EDGE_THRESHOLD_UP
+                and up_edge >= down_edge):
+            side, entry = "up", up_entry
+        elif (down_aligned and down_price_ok and down_edge >= MIN_EDGE_THRESHOLD_DOWN):
+            side, entry = "down", down_entry
+        if side is None:
+            continue
+        size = notional / entry  # shares purchased
+        won = (side == "up" and y[i] == 1) or (side == "down" and y[i] == 0)
+        # Polymarket v2 charges fees in shares on the BUY side: you pay
+        # `notional` USDC and receive `size - fee_shares` shares of the bought
+        # outcome. On a win each share pays $1; on a loss it pays $0.
+        fee_shares = size * FEE_RATE * entry * (1.0 - entry)
+        if won:
+            pnl[i] = (size - fee_shares) * 1.0 - notional
+        else:
+            pnl[i] = -notional
+    return float(pnl.sum()), pnl
+
+
+def bootstrap_pnl_delta_ci(
+    pnl_a: np.ndarray, pnl_b: np.ndarray, n_bootstrap: int = 1000, seed: int = 42
+) -> tuple[float, float]:
+    """95% CI on (A - B) total PnL, paired bootstrap on row indices."""
+    rng = np.random.default_rng(seed)
+    n = len(pnl_a)
+    diffs = pnl_a - pnl_b
+    sums = rng.choice(diffs, size=(n_bootstrap, n), replace=True).sum(axis=1)
+    return float(np.quantile(sums, 0.025)), float(np.quantile(sums, 0.975))
+
+
+def apply_q4_gate(
+    reliability: list[dict],
+    side_gap: dict,
+    holdout_logloss: float,
+    v2_holdout_logloss: float,
+    pnl_delta_ci: tuple[float, float],
+) -> tuple[bool, list[str]]:
+    """Apply the design's §Q4 acceptance gate. Returns (ship_ok, failures)."""
+    failures = []
+    # All n>=30 bins within +/-5pt
+    for r in reliability:
+        if r["n"] >= 30 and r["gap_pt"] is not None:
+            if abs(r["gap_pt"]) > GATE_BIN_TOL_PT:
+                failures.append(f"bin {r['bin']} gap {r['gap_pt']:+.1f}pt outside +/-{GATE_BIN_TOL_PT}pt (n={r['n']})")
+    # Tail-bin specific
+    for r in reliability:
+        if r["bin"] == "0.80-0.85" and r["n"] >= 30 and r["gap_pt"] is not None:
+            if r["gap_pt"] < GATE_TAIL_8085_MIN_PT:
+                failures.append(f"bin 0.80-0.85 gap {r['gap_pt']:+.1f}pt < required {GATE_TAIL_8085_MIN_PT:+.1f}pt")
+        if r["bin"] == "0.85-0.90" and r["n"] >= 30 and r["gap_pt"] is not None:
+            if r["gap_pt"] < GATE_TAIL_8590_MIN_PT:
+                failures.append(f"bin 0.85-0.90 gap {r['gap_pt']:+.1f}pt < required {GATE_TAIL_8590_MIN_PT:+.1f}pt")
+    # DOWN overall
+    dg = side_gap.get("down", {}).get("gap_pt")
+    if dg is not None and abs(dg) > GATE_DOWN_TOL_PT:
+        failures.append(f"DOWN overall gap {dg:+.1f}pt outside +/-{GATE_DOWN_TOL_PT}pt")
+    # Log-loss margin vs v2
+    if holdout_logloss > v2_holdout_logloss - GATE_LOGLOSS_MARGIN_NATS:
+        failures.append(
+            f"held-out log-loss {holdout_logloss:.4f} not better than v2 ({v2_holdout_logloss:.4f}) by >={GATE_LOGLOSS_MARGIN_NATS} nats"
+        )
+    # PnL veto
+    lo, hi = pnl_delta_ci
+    if hi < 0:
+        failures.append(f"PnL veto: 95% CI on (v3 - v2) total PnL = [{lo:+.2f}, {hi:+.2f}] entirely below zero")
+    return (len(failures) == 0, failures)
+
+
+def compute_v2_predictions(df: pd.DataFrame, v2_coefs_path: str) -> np.ndarray:
+    """Re-derive v2's predicted p_up from features (avoids ledger dependency)."""
+    with open(v2_coefs_path) as f:
+        c = json.load(f)
+    features = c["features"]
+    mean = np.array(c["scaler_mean"])
+    scale = np.array(c["scaler_scale"])
+    coef = np.array(c["logistic_coef"])
+    intercept = float(c["logistic_intercept"])
+    # Build the v2 feature columns on df (needs z built first).
+    df = add_v0_features(df)
+    X = df[features].to_numpy()
+    Xs = (X - mean) / scale
+    logits = Xs @ coef + intercept
+    return 1.0 / (1.0 + np.exp(-logits))
+
+
+def train_variant(
+    corpus_full: pd.DataFrame,
+    variant: str,
+    *,
+    db_path: str,
+    seed: int = 42,
+    v2_coefs_path: str = "polypocket/model_v2_coefs.json",
+) -> dict[str, Any]:
+    """Train one variant end-to-end. Returns a dict with model artifacts + metrics."""
+    if variant == "v0":
+        df = add_v0_features(corpus_full).reset_index(drop=True)
+        features = list(V0_FEATURES)
+    elif variant == "v0.1":
+        sub = corpus_full[
+            corpus_full["up_bids_json"].notna() & corpus_full["down_bids_json"].notna()
+        ].reset_index(drop=True)
+        df = add_v01_features(sub, db_path=db_path).reset_index(drop=True)
+        features = list(V0_FEATURES) + list(V01_EXTRA_FEATURES)
+    else:
+        raise ValueError(f"unknown variant: {variant}")
+
+    train, cal, heldout = chrono_split(df)
+    y_train = train["outcome_int"].to_numpy()
+    y_heldout = heldout["outcome_int"].to_numpy()
+
+    X_train_raw = train[features].to_numpy()
+    X_heldout_raw = heldout[features].to_numpy()
+    scaler = StandardScaler().fit(X_train_raw)
+    X_train = scaler.transform(X_train_raw)
+    X_heldout = scaler.transform(X_heldout_raw)
+
+    timestamps = pd.to_datetime(train["decision_timestamp"]).to_numpy()
+    model, chosen_C, cv_means = fit_logistic(
+        X_train, y_train, timestamps=timestamps, seed=seed
+    )
+
+    p_heldout = model.predict_proba(X_heldout)[:, 1]
+    holdout_logloss = float(log_loss(y_heldout, p_heldout, labels=[0, 1]))
+    holdout_brier = float(brier_score_loss(y_heldout, p_heldout))
+
+    # Reliability + side gap
+    reliability = reliability_table(p_heldout, y_heldout, seed=seed)
+    side_gap = side_overall_gap(
+        p_heldout, y_heldout,
+        heldout["up_ask"].to_numpy(), heldout["down_ask"].to_numpy(),
+    )
+
+    # v2-on-v3-holdout for the v2-vs-v3 head-to-head + gate
+    p_v2_heldout = compute_v2_predictions(heldout, v2_coefs_path)
+    v2_holdout_logloss = float(log_loss(y_heldout, p_v2_heldout, labels=[0, 1]))
+    v2_reliability = reliability_table(p_v2_heldout, y_heldout, seed=seed)
+    v2_side_gap = side_overall_gap(
+        p_v2_heldout, y_heldout,
+        heldout["up_ask"].to_numpy(), heldout["down_ask"].to_numpy(),
+    )
+
+    # PnL simulation: v3 vs v2 under the runtime gate, paired bootstrap
+    up_ask = heldout["up_ask"].to_numpy()
+    down_ask = heldout["down_ask"].to_numpy()
+    ub_json = heldout["up_bids_json"].tolist()
+    db_json = heldout["down_bids_json"].tolist()
+    v3_total, v3_pnl = simulate_pnl(p_heldout, y_heldout, up_ask, down_ask, ub_json, db_json)
+    v2_total, v2_pnl = simulate_pnl(p_v2_heldout, y_heldout, up_ask, down_ask, ub_json, db_json)
+    pnl_delta_ci = bootstrap_pnl_delta_ci(v3_pnl, v2_pnl, seed=seed)
+
+    # §Q4 gate
+    ship_ok, failures = apply_q4_gate(
+        reliability, side_gap, holdout_logloss, v2_holdout_logloss, pnl_delta_ci
+    )
+
+    # Isotonic ablation (report-only, may override default if it wins per design §8)
+    cal_X = scaler.transform(cal[features].to_numpy())
+    p_cal = model.predict_proba(cal_X)[:, 1]
+    iso = IsotonicRegression(out_of_bounds="clip").fit(p_cal, cal["outcome_int"].to_numpy())
+    p_heldout_iso = iso.predict(p_heldout)
+    iso_logloss = float(log_loss(y_heldout, np.clip(p_heldout_iso, 1e-6, 1 - 1e-6), labels=[0, 1]))
+    iso_reliability = reliability_table(p_heldout_iso, y_heldout, seed=seed)
+
+    # Feature hull (min/max from training slice, for runtime out-of-domain check)
+    hull = {f: [float(train[f].min()), float(train[f].max())] for f in features}
+
+    # Per-feature ablation for v0.1 only (drop-one)
+    per_feature_ablation: dict[str, dict] = {}
+    if variant == "v0.1":
+        for drop in V01_EXTRA_FEATURES:
+            keep = [f for f in features if f != drop]
+            # Re-fit a fresh scaler+model on the reduced feature set
+            sub_scaler = StandardScaler().fit(train[keep].to_numpy())
+            sub_X_tr = sub_scaler.transform(train[keep].to_numpy())
+            sub_X_he = sub_scaler.transform(heldout[keep].to_numpy())
+            sub_m = LogisticRegression(
+                C=chosen_C, penalty="l2", solver="lbfgs", max_iter=2000, random_state=seed
+            )
+            sub_m.fit(sub_X_tr, y_train)
+            p_sub = sub_m.predict_proba(sub_X_he)[:, 1]
+            sub_loss = float(log_loss(y_heldout, p_sub, labels=[0, 1]))
+            per_feature_ablation[drop] = {
+                "dropped": drop,
+                "remaining_features": keep,
+                "holdout_logloss": sub_loss,
+                "delta_vs_full": sub_loss - holdout_logloss,
+            }
+
+    return {
+        "variant": variant,
+        "features": features,
+        "n_train": int(len(train)),
+        "n_cal": int(len(cal)),
+        "n_heldout": int(len(heldout)),
+        "date_ranges": {
+            "train": [str(train["decision_timestamp"].iloc[0]), str(train["decision_timestamp"].iloc[-1])],
+            "cal":   [str(cal["decision_timestamp"].iloc[0]), str(cal["decision_timestamp"].iloc[-1])],
+            "heldout": [str(heldout["decision_timestamp"].iloc[0]), str(heldout["decision_timestamp"].iloc[-1])],
+        },
+        "base_rate_train": float(y_train.mean()),
+        "base_rate_heldout": float(y_heldout.mean()),
+        "chosen_C": chosen_C,
+        "cv_means": cv_means,
+        "holdout_logloss": holdout_logloss,
+        "holdout_brier": holdout_brier,
+        "reliability": reliability,
+        "side_gap": side_gap,
+        "v2_holdout_logloss": v2_holdout_logloss,
+        "v2_reliability": v2_reliability,
+        "v2_side_gap": v2_side_gap,
+        "pnl_v3_total": v3_total,
+        "pnl_v2_total": v2_total,
+        "pnl_delta_ci": list(pnl_delta_ci),
+        "iso_holdout_logloss": iso_logloss,
+        "iso_reliability": iso_reliability,
+        "ship_ok": ship_ok,
+        "gate_failures": failures,
+        "scaler_mean": scaler.mean_.tolist(),
+        "scaler_scale": scaler.scale_.tolist(),
+        "logistic_coef": model.coef_[0].tolist(),
+        "logistic_intercept": float(model.intercept_[0]),
+        "feature_hull": hull,
+        "per_feature_ablation": per_feature_ablation,
+    }
+
+
+def write_coefs_json(result: dict, path: str, trained_at: str, *, git_sha: str | None = None) -> None:
+    """Write a v2-compatible coefs JSON with a v3 metadata block."""
+    payload = {
+        "model_version": "v3",
+        "trained_on_git_sha": git_sha,
+        "trained_at": trained_at,
+        "shipping_config": f"{result['variant']}+no-iso",
+        "corpus": {
+            "source": "paper post-G1",
+            "total_n": result["n_train"] + result["n_cal"] + result["n_heldout"],
+            "train_n": result["n_train"],
+            "cal_n": result["n_cal"],
+            "held_n": result["n_heldout"],
+            "held_dates": result["date_ranges"]["heldout"],
+            "base_rate_train": result["base_rate_train"],
+            "base_rate_held": result["base_rate_heldout"],
+        },
+        "features": result["features"],
+        "scaler_mean": result["scaler_mean"],
+        "scaler_scale": result["scaler_scale"],
+        "logistic_coef": result["logistic_coef"],
+        "logistic_intercept": result["logistic_intercept"],
+        "logistic_C": result["chosen_C"],
+        "isotonic_x": None,
+        "isotonic_y": None,
+        "feature_hull": result["feature_hull"],
+        "held_out_metrics": {
+            "log_loss_v3": result["holdout_logloss"],
+            "log_loss_v2_on_v3_holdout": result["v2_holdout_logloss"],
+            "brier_v3": result["holdout_brier"],
+            "reliability_v3": result["reliability"],
+            "reliability_v2": result["v2_reliability"],
+            "side_gap_v3": result["side_gap"],
+            "side_gap_v2": result["v2_side_gap"],
+            "ev_v3_total_pnl": result["pnl_v3_total"],
+            "ev_v2_total_pnl": result["pnl_v2_total"],
+            "ev_delta_ci": result["pnl_delta_ci"],
+            "ev_veto": result["pnl_delta_ci"][1] < 0,
+            "gate_pass": result["ship_ok"],
+            "gate_failures": result["gate_failures"],
+        },
+        "ablations": {
+            "no_isotonic_log_loss": result["holdout_logloss"],
+            "with_isotonic_log_loss": result["iso_holdout_logloss"],
+            "per_feature": result["per_feature_ablation"],
+        },
+        "metadata": {
+            "variant": result["variant"],
+        },
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=False)
+
+
+def _fmt_reliability_table(rows: list[dict]) -> str:
+    lines = [
+        f"| bin | n | mean_pred | actual | gap_pt | 95% CI |",
+        f"|---|---:|---:|---:|---:|---:|",
+    ]
+    for r in rows:
+        if r["n"] == 0:
+            lines.append(f"| {r['bin']} | 0 | — | — | — | — |")
+        else:
+            lines.append(
+                f"| {r['bin']} | {r['n']} | {r['pred']:.3f} | {r['actual']:.3f} | "
+                f"{r['gap_pt']:+.1f} | [{r['ci'][0]:.3f}, {r['ci'][1]:.3f}] |"
+            )
+    return "\n".join(lines)
+
+
+def write_report(results: list[dict], path: str, *, winner_variant: str | None) -> None:
+    lines = []
+    lines.append("# v3 logistic p_up training report")
+    lines.append("")
+    lines.append("_seed=42; sklearn LogisticRegression L2; TimeSeriesSplit n_splits=5_")
+    lines.append("")
+    if winner_variant is None:
+        lines.append("## Gate verdict: ship_ok = False (no variant passed §Q4)")
+    else:
+        lines.append(f"## Gate verdict: ship_ok = True — shipped variant: **{winner_variant}**")
+    lines.append("")
+    for r in results:
+        lines.append(f"## Variant: `{r['variant']}` ({'PASS' if r['ship_ok'] else 'FAIL'})")
+        lines.append("")
+        lines.append(f"- Features: {r['features']}")
+        lines.append(f"- N train={r['n_train']} cal={r['n_cal']} heldout={r['n_heldout']}")
+        lines.append(f"- train dates: {r['date_ranges']['train'][0]} ->{r['date_ranges']['train'][1]}")
+        lines.append(f"- heldout dates: {r['date_ranges']['heldout'][0]} ->{r['date_ranges']['heldout'][1]}")
+        lines.append(f"- base rate (up): train={r['base_rate_train']:.3f}  held={r['base_rate_heldout']:.3f}")
+        lines.append(f"- chosen L2 C = {r['chosen_C']}; CV means: {r['cv_means']}")
+        lines.append("")
+        lines.append(f"### Held-out metrics")
+        lines.append(f"- v3 log-loss = {r['holdout_logloss']:.4f}; v3 Brier = {r['holdout_brier']:.4f}")
+        lines.append(f"- v2-on-v3-holdout log-loss = {r['v2_holdout_logloss']:.4f}")
+        lines.append(f"- v2-on-v2-holdout log-loss (reference, _model_v2_training.md) = {V2_HOLDOUT_LOGLOSS:.4f}")
+        lines.append(f"- delta (v3 - v2) on v3 holdout = {r['holdout_logloss']-r['v2_holdout_logloss']:+.4f} nats (required ≤ -0.005 for gate)")
+        lines.append("")
+        lines.append("### v3 reliability (held-out)")
+        lines.append(_fmt_reliability_table(r["reliability"]))
+        lines.append("")
+        lines.append("### v2 reliability on the same held-out rows")
+        lines.append(_fmt_reliability_table(r["v2_reliability"]))
+        lines.append("")
+        lines.append(f"### Side decomposition (gate-aligned)")
+        for side in ("up", "down"):
+            sg = r["side_gap"][side]
+            v2sg = r["v2_side_gap"][side]
+            if sg["n"] == 0:
+                lines.append(f"- {side.upper()}-bias: n=0")
+                continue
+            lines.append(
+                f"- {side.upper()}-bias v3: n={sg['n']} mean_pred={sg['mean_pred']:.3f} "
+                f"actual={sg['mean_actual']:.3f} gap={sg['gap_pt']:+.1f}pt | "
+                f"v2: n={v2sg['n']} gap={v2sg['gap_pt']:+.1f}pt"
+            )
+        lines.append("")
+        lines.append("### Simulated EV under live gate (held-out)")
+        lines.append(f"- v3 total PnL: ${r['pnl_v3_total']:+.2f}")
+        lines.append(f"- v2 total PnL: ${r['pnl_v2_total']:+.2f}")
+        lines.append(f"- delta (v3 - v2) 95% CI: [${r['pnl_delta_ci'][0]:+.2f}, ${r['pnl_delta_ci'][1]:+.2f}]")
+        lines.append(f"- EV veto: {r['pnl_delta_ci'][1] < 0}")
+        lines.append("")
+        lines.append("### Isotonic ablation")
+        lines.append(f"- no-iso log-loss: {r['holdout_logloss']:.4f}")
+        lines.append(f"- with-iso log-loss: {r['iso_holdout_logloss']:.4f}")
+        lines.append(f"- delta (iso - no-iso) = {r['iso_holdout_logloss']-r['holdout_logloss']:+.4f} nats "
+                     f"(ship iso only if ≤ -0.01 AND iso bin gate passes)")
+        lines.append("")
+        if r["variant"] == "v0.1" and r["per_feature_ablation"]:
+            lines.append("### Per-feature ablation (drop-one, retrain at chosen C)")
+            lines.append("| dropped | held-out log-loss | Δ vs full |")
+            lines.append("|---|---:|---:|")
+            for k, v in r["per_feature_ablation"].items():
+                lines.append(f"| {k} | {v['holdout_logloss']:.4f} | {v['delta_vs_full']:+.4f} |")
+            lines.append("")
+        if r["gate_failures"]:
+            lines.append("### Gate failures")
+            for f in r["gate_failures"]:
+                lines.append(f"- {f}")
+            lines.append("")
+    lines.append("")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+def pick_winner(results: list[dict]) -> str | None:
+    """Mechanical winner selection per impl plan §Step 4.
+
+    1. If both pass §Q4: keep v0 (simpler/larger support), unless v0.1 beats v0
+       on 0.80-0.85 / 0.85-0.90 bins by ≥2pt — then ship v0.1.
+    2. If only one passes: ship that one.
+    3. If neither passes: return None (halt, surface to user).
+    """
+    by_v = {r["variant"]: r for r in results}
+    v0 = by_v.get("v0")
+    v01 = by_v.get("v0.1")
+
+    if v0 and v01 and v0["ship_ok"] and v01["ship_ok"]:
+        def _bin_gap(r, label):
+            for b in r["reliability"]:
+                if b["bin"] == label and b["n"] >= 30 and b["gap_pt"] is not None:
+                    return b["gap_pt"]
+            return None
+        margins = []
+        for label in ("0.80-0.85", "0.85-0.90"):
+            g0 = _bin_gap(v0, label)
+            g01 = _bin_gap(v01, label)
+            if g0 is not None and g01 is not None:
+                margins.append(g01 - g0)
+        if margins and all(m >= 2.0 for m in margins):
+            return "v0.1"
+        return "v0"
+
+    if v0 and v0["ship_ok"]:
+        return "v0"
+    if v01 and v01["ship_ok"]:
+        return "v0.1"
+    return None
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--corpus", default="_bmad-output/v3_corpus.parquet")
+    p.add_argument("--db", default="paper_trades.db", help="SQLite path for window_book_samples lookups (v0.1 only)")
+    p.add_argument("--variant", choices=["v0", "v0.1", "both"], default="both")
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--out-coefs", default="polypocket/model_v3_coefs.candidate.json")
+    p.add_argument("--out-report", default="scripts/_model_v3_training.md")
+    p.add_argument("--baseline-coefs", default="polypocket/model_v2_coefs.json")
+    args = p.parse_args()
+
+    corpus = pd.read_parquet(args.corpus)
+    # Filter to t_remaining > 0 (already in exporter, defense-in-depth)
+    corpus = corpus[corpus["t_remaining"] > 0].reset_index(drop=True)
+    print(f"Loaded corpus: {len(corpus)} rows, "
+          f"{corpus['decision_timestamp'].min()} ->{corpus['decision_timestamp'].max()}")
+
+    variants = ["v0", "v0.1"] if args.variant == "both" else [args.variant]
+    results = []
+    for v in variants:
+        print(f"\n--- Training variant: {v} ---")
+        r = train_variant(corpus, v, db_path=args.db, seed=args.seed, v2_coefs_path=args.baseline_coefs)
+        print(f"  ship_ok={r['ship_ok']}, holdout_logloss={r['holdout_logloss']:.4f}, "
+              f"PnL v3=${r['pnl_v3_total']:+.2f}, v2=${r['pnl_v2_total']:+.2f}")
+        if r["gate_failures"]:
+            print(f"  failures: {r['gate_failures']}")
+        results.append(r)
+
+    winner = pick_winner(results)
+    trained_at = datetime.utcnow().isoformat() + "Z"
+    write_report(results, args.out_report, winner_variant=winner)
+    print(f"\nReport written to {args.out_report}")
+
+    if winner is not None:
+        winning = next(r for r in results if r["variant"] == winner)
+        write_coefs_json(winning, args.out_coefs, trained_at)
+        print(f"Coefs written to {args.out_coefs} (variant={winner})")
+        return 0
+    else:
+        print("NO VARIANT PASSED §Q4. No coefs file written.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The v3 logistic refit (`docs/plans/2026-05-17-logistic-p-up-v3-*`) was investigated end-to-end. **Halted at Step 4 of the impl plan with negative result.** Both candidate variants fail §Q4. v2 remains the active gate; no production code changed.

This PR commits the investigation artifacts so the next iteration has the training infrastructure and the evidence ready, instead of re-discovering both.

## Why halted

The design targeted "regime drift on the 0.80+ bins" diagnosed at −10.2pt (0.80–0.85) / −13.8pt (0.85–0.90) in `_bmad-output/v2_failure_diagnostics_modelver.md`. Reproducing that filter (`trade_fired=1` + bids populated + v2 column populated) and splitting by time:

| slice | n | 0.80-0.85 v2 gap |
|---|---:|---:|
| FULL post-cutover (2026-04-24 → 2026-05-18) | 689 | **−10.8pt** (reproduces diagnostic) |
| EARLY (2026-04-24 → 2026-05-11) | 261 | **−20.9pt** |
| LATE (2026-05-11 → 2026-05-18 = v3 holdout window) | 428 | **−0.3pt** |

The bad calibration was concentrated in the early post-cutover period when v2 had limited tail-bin support; the bin has self-healed via accumulating data. v3 had nothing left to beat at the 0.80+ tail.

## Headline results

| variant | holdout logloss | vs v2 same holdout | 0.80-0.85 v3/v2 | PnL delta CI |
|---|---:|---:|---:|---:|
| v0 (4-feat, n=5,275) | 0.3356 | −0.0006 nats (need ≤ −0.005) | −5.9pt / −4.2pt | [−\$33, +\$169] no veto |
| v0.1 (8-feat, n=1,744) | 0.4776 | **+0.0145 nats worse** | +8.8pt / +1.2pt | **[−\$588, −\$243] VETO fired** |

v0.1's book-depth features actively hurt; the drop-one ablation showed `pre_decision_pmc_sigma` even slightly improves log-loss when removed.

## What's in this PR

- `scripts/train_model_v3.py` — deterministic training pipeline (~770 lines). v0 / v0.1 corpora, time-series 5-fold CV with L2 grid, no-iso shipping + with-iso ablation, drop-one per-feature ablation, §Q4 gate enforcement, simulated PnL with bootstrap CI replicating the runtime gate. Reusable for any future refit.
- `scripts/_model_v3_training.md` — full negative-result report with halt summary at top.
- `docs/plans/2026-05-17-logistic-p-up-v3-design.md` + `-implementation.md` — design + impl plan with `STATUS: HALTED` headers documenting the result.
- `.gitignore` — add `_bmad-output/*.parquet` for training-corpus artifacts.

**NOT in this PR:**
- No `polypocket/model_v3_coefs.json` (correctly not written — no variant passed).
- No changes to `polypocket/observer.py`, `signal.py`, `ledger.py`, `config.py`, `bot.py`. The §Q4 halt fired before the integration steps.

## Recommended next actions

1. **Default: monitor v2 health.** `scripts/_model_health.md` is the canonical source for current drift; refit only when fresh drift appears.
2. **If you want a refit, pivot to the bins that ARE drifting.** Current model-health shows 0.60–0.65 (+8.8pt) and 0.65–0.70 (+10.4pt) under-confident — opposite direction from v3's target. Would need a new design.
3. **Model class change** (GBDT etc.) — tracked in #27.

## Test plan

- [x] `python scripts/train_model_v3.py --variant both` runs end-to-end, exits 1, writes no coefs file
- [x] Re-running with same `--seed` produces a bitwise-identical training output (determinism via `random_state=42`)
- [x] `_bmad-output/v3_corpus.parquet` is gitignored
- [x] `.env` confirmed `MODEL_VERSION=v2` and `ENTRY_MODE=fak`; no gate behavior change
- [x] `polypocket/` directory unchanged on this branch vs `main` (verified by file list of the commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)